### PR TITLE
Raise Error if generator doesn't return string

### DIFF
--- a/src/fandango/language/grammar.py
+++ b/src/fandango/language/grammar.py
@@ -712,6 +712,9 @@ class Grammar(NodeVisitor):
 
     def generate(self, symbol: str | NonTerminal = "<start>") -> DerivationTree:
         string = self.generate_string(symbol)
+        if not (isinstance(string, str) or isinstance(string, tuple)):
+            raise TypeError(f"Generator {self.generators[symbol]} must return string or tuple")
+        
         if isinstance(string, tuple):
             return DerivationTree.from_tree(string)
         else:

--- a/src/fandango/language/tree.py
+++ b/src/fandango/language/tree.py
@@ -77,6 +77,8 @@ class DerivationTree:
     @staticmethod
     def from_tree(tree: Tuple[str, List[Tuple[str, List]]]) -> "DerivationTree":
         symbol, children = tree
+        if not isinstance(symbol, str):
+            raise TypeError(f"{symbol} must be string")
         if symbol.startswith("<") and symbol.endswith(">"):
             symbol = NonTerminal(symbol)
         else:


### PR DESCRIPTION
Added checks if the return value of a generator is a string or a tuple, else raise TypeError. Also in case of tuples, check if symbols are strings.
Fixes #76 