### PR TITLE
Added read_only flag

### DIFF
--- a/src/fandango/cli/__init__.py
+++ b/src/fandango/cli/__init__.py
@@ -939,7 +939,7 @@ def fuzz_command(args):
 
         # Ensure that every generated file can be parsed
         # and returns the same string as the original
-        temp_dir = tempfile.TemporaryDirectory(delete=False)
+        temp_dir = tempfile.TemporaryDirectory()
         args.directory = temp_dir.name
         args.format = "string"
         output_population(population, args, file_mode=file_mode, output_on_stdout=False)

--- a/src/fandango/evolution/algorithm.py
+++ b/src/fandango/evolution/algorithm.py
@@ -155,6 +155,8 @@ class Fandango:
     def fix_individual(self, individual: DerivationTree) -> DerivationTree:
         _, failing_trees = self.evaluator.evaluate_individual(individual)
         for failing_tree in failing_trees:
+            if failing_tree.tree.read_only:
+                continue
             for operator, value, side in failing_tree.suggestions:
                 from fandango.constraints.fitness import Comparison, ComparisonSide
 

--- a/src/fandango/evolution/mutation.py
+++ b/src/fandango/evolution/mutation.py
@@ -42,6 +42,7 @@ class SimpleMutation(MutationOperator):
 
         # Collect the failing subtrees
         failing_subtrees = [ft.tree for ft in failing_trees]
+        failing_subtrees = list(filter(lambda x: not x.read_only, failing_subtrees))
 
         # If there is nothing to mutate, return the individual as is.
         if not failing_subtrees:

--- a/src/fandango/evolution/population.py
+++ b/src/fandango/evolution/population.py
@@ -82,6 +82,8 @@ class PopulationManager:
     ) -> DerivationTree:
         fixes_made = 0
         for failing_tree in failing_trees:
+            if failing_tree.tree.read_only:
+                continue
             for operator, value, side in failing_tree.suggestions:
                 if operator == Comparison.EQUAL and side == ComparisonSide.LEFT:
                     suggested_tree = self.grammar.parse(

--- a/src/fandango/language/grammar.py
+++ b/src/fandango/language/grammar.py
@@ -249,7 +249,11 @@ class NonTerminalNode(Node):
         if self.symbol not in grammar:
             raise ValueError(f"Symbol {self.symbol} not found in grammar")
         if self.symbol in grammar.generators:
-            return [grammar.generate(self.symbol)]
+            generated = grammar.generate(self.symbol)
+            # Prevent children from being overwritten without executing generator
+            generated.set_all_read_only(True)
+            generated.read_only = False
+            return [generated]
         children = grammar[self.symbol].fuzz(grammar, max_nodes - 1)
         return [DerivationTree(self.symbol, children)]
 

--- a/src/fandango/language/tree.py
+++ b/src/fandango/language/tree.py
@@ -17,10 +17,12 @@ class DerivationTree:
         symbol: Symbol,
         children: Optional[List["DerivationTree"]] = None,
         parent: Optional["DerivationTree"] = None,
+        read_only: bool = False
     ):
         self.hash_cache = None
         self._parent = parent
         self.symbol = symbol
+        self.read_only = read_only
         self._children = []
         self._size = 1
         self.set_children(children or [])
@@ -44,6 +46,11 @@ class DerivationTree:
         self.hash_cache = None
         if self._parent is not None:
             self._parent.invalidate_hash()
+
+    def set_all_read_only(self, read_only: bool):
+        self.read_only = read_only
+        for child in self._children:
+            child.set_all_read_only(read_only)
 
     def set_children(self, children: List["DerivationTree"]):
         self._children = children
@@ -121,7 +128,7 @@ class DerivationTree:
             return memo[id(self)]
 
         # Create a new instance without copying the parent
-        copied = DerivationTree(self.symbol, [])
+        copied = DerivationTree(self.symbol, [], read_only=self.read_only)
         memo[id(self)] = copied
 
         # Deepcopy the children
@@ -426,7 +433,7 @@ class DerivationTree:
         """
         Replace the subtree rooted at the given node with the new subtree.
         """
-        if self == tree_to_replace:
+        if self == tree_to_replace and not self.read_only:
             return new_subtree
         else:
             return DerivationTree(
@@ -435,25 +442,28 @@ class DerivationTree:
                     child.replace(tree_to_replace, new_subtree)
                     for child in self._children
                 ],
+                read_only=self.read_only,
             )
 
-    def get_non_terminal_symbols(self) -> Set[NonTerminal]:
+    def get_non_terminal_symbols(self, exclude_read_only=True) -> Set[NonTerminal]:
         """
         Retrieve all non-terminal symbols present in the derivation tree.
         """
         symbols = set()
-        if self.symbol.is_non_terminal:
+        if self.symbol.is_non_terminal and not (exclude_read_only and self.read_only):
             symbols.add(self.symbol)
         for child in self._children:
-            symbols.update(child.get_non_terminal_symbols())
+            symbols.update(child.get_non_terminal_symbols(exclude_read_only))
         return symbols
 
-    def find_all_nodes(self, symbol: NonTerminal) -> List["DerivationTree"]:
+    def find_all_nodes(
+        self, symbol: NonTerminal, exclude_read_only=True
+    ) -> List["DerivationTree"]:
         """
         Find all nodes in the derivation tree with the given non-terminal symbol.
         """
         nodes = []
-        if self.symbol == symbol:
+        if self.symbol == symbol and not (exclude_read_only and self.read_only):
             nodes.append(self)
         for child in self._children:
             nodes.extend(child.find_all_nodes(symbol))


### PR DESCRIPTION
Added a read_only-flag to DerivationTree. This flag protects that direct part of the DerivationTree from being overwritten using crossovers, mutations and replacements.