### PR TITLE
Fix/invalid tree size

### DIFF
--- a/evaluation/vs_isla/tar_evaluation/tar.fan
+++ b/evaluation/vs_isla/tar_evaluation/tar.fan
@@ -89,8 +89,8 @@
 ## File Size Constraint "file_size_constr" (generator in grammar)
 
 forall <entr> in <entry>:
-    int(<entr>.<header>.<file_size>, 8) >= 10 and
-    int(<entr>.<header>.<file_size>, 8) <= 100
+    int(str(<entr>.<header>.<file_size>), 8) >= 10 and
+    int(str(<entr>.<header>.<file_size>), 8) <= 100
 ;
 
 ## File Name Length Constraint "file_name_length_constraint" (generator in grammar)
@@ -306,7 +306,7 @@ def generate_content():
 ## 16. Content Size Constraint "content_size_constr" (constraint for the fuzzer)
 
 forall <entr> in <entry>:
-    str(<entr>.<content>.<content_chars>) == str(<entr>.<content>.<content_chars>).ljust(int(<entr>.<header>.<file_size>, 8), " ")
+    str(<entr>.<content>.<content_chars>) == str(<entr>.<content>.<content_chars>).ljust(int(str(<entr>.<header>.<file_size>), 8), " ")
 ;
 
 ## 17. Final Entry Length Constraint "final_entry_length_constraint" (generator in grammar)

--- a/src/fandango/language/tree.py
+++ b/src/fandango/language/tree.py
@@ -89,16 +89,21 @@ class DerivationTree:
 
     def set_children(self, children: List["DerivationTree"]):
         self._children = children
-        self._size = 1 + sum(child.size() for child in self._children)
+        self._update_size(1 + sum(child.size() for child in self._children))
         for child in self._children:
             child._parent = self
         self.invalidate_hash()
 
     def add_child(self, child: "DerivationTree"):
         self._children.append(child)
-        self._size += child.size()
+        self._update_size(self.size() + child.size())
         child._parent = self
         self.invalidate_hash()
+
+    def _update_size(self, new_val: int):
+        if self._parent is not None:
+            self._parent._update_size(self.parent.size() + new_val - self._size)
+        self._size = new_val
 
     def find_all_trees(self, symbol: NonTerminal) -> List["DerivationTree"]:
         trees = sum(

--- a/src/fandango/language/tree.py
+++ b/src/fandango/language/tree.py
@@ -608,7 +608,7 @@ class DerivationTree:
     ## Comparison operations
     def __eq__(self, other):
         if isinstance(other, DerivationTree):
-            return self.__tree__() == other.__tree__()
+            return self.__hash__() == other.__hash__()
         return self.value() == other
 
     def __le__(self, other):

--- a/tests/resources/dynamic_repetition.fan
+++ b/tests/resources/dynamic_repetition.fan
@@ -1,12 +1,11 @@
 from struct import unpack
+import random
 
-<start> ::= <len> '(' <inner>{min(int(<len>), 4)} ')'
-<len> ::= <number>
-<inner> ::= <len> <letter>{min(int(<len>), 4)}
+<start> ::= <len> '(' <inner>{int(<len>)} ')'
+<len> ::= <number> :: str(random.randrange(1, 10))
+<inner> ::= <len> <letter>{int(<len>)}
 <letter> ::= r'[a-zA-Z]'
 
 <number> ::= <number_start> <number_tailing>*
 <number_start> ::= '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
 <number_tailing> ::= '0' | <number_start>
-
-where 1 <= int(<len>) and int(<len>) <= 4

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -82,6 +82,6 @@ class ConstraintTest(unittest.TestCase):
         for solution in solutions:
             len_outer = solution.children[0].to_int()
             self.assertEqual(len_outer, len(solution.children) - 3)
-            for tree in solution.children[2:-2]:
-                len_inner = tree.children[0].to_int()
-                self.assertEqual(len_inner, len(tree.children) - 1)
+            for inner in solution.children[2:-1]:
+                len_inner = inner.children[0].to_int()
+                self.assertEqual(len_inner, len(inner.children) - 1)


### PR DESCRIPTION
- Fixes a bug where a tree size change wasn't propagated to the tree root.
- Fixes a bug where length tags used for computed length repetitions were not set to read-only.