### PR TITLE
Added documentation for converters; better error messages

### DIFF
--- a/docs/Conversion.md
+++ b/docs/Conversion.md
@@ -20,7 +20,7 @@ Fandango uses a special form of [generators](sec:generators) to handle these, na
 Let's have a look at how these work.
 
 
-## Encoding Data
+## Encoding Data During Fuzzing
 
 In Fandango, a [generator](sec:generators) expression can contain _symbols_ (enclosed in `<...>`) as elements.
 When fuzzing, this has the effect of Fandango using the grammar to
@@ -80,3 +80,29 @@ The resulting [`encode.fan`](encode.fan) spec allows us to encode and embed bina
 ```
 
 In the same vein, one can use functions for compressing data or any other kind of conversion.
+
+
+## Decoding Parsed Data
+
+```{code-cell}
+!echo -n 'Data: RmFuZGFuZ2+O' | fandango parse -f encode-decode.fan -o - --format=grammar
+```
+
+```{code-cell}
+:tags: ["remove-input"]
+from Tree import Tree
+
+tree = Tree('<start>',
+  Tree(b'Data: '),
+  Tree('<item>',
+    Tree(b'RmFuZGFuZ2+O'),
+    sources=[
+      Tree('<data>',
+        Tree(b'Fandango'),
+        Tree('<byte>', Tree('<_byte>', Tree(b'\x8e')))
+      ),
+    ]
+  )
+)
+tree.visualize()
+```

--- a/docs/Conversion.md
+++ b/docs/Conversion.md
@@ -11,10 +11,10 @@ kernelspec:
 ---
 
 (sec:conversion)=
-# Conversion and Compression
+# Data Conversions
 
 When defining a complex input format, some parts may be the result of applying an _operation_ on another, more structured part.
-Most importantly, content may be _encoded_, _compressed_, or _sanitized_.
+Most importantly, content may be _encoded_, _compressed_, or _converted_.
 
 Fandango uses a special form of [generators](sec:generators) to handle these, namely generators with _symbols_.
 Let's have a look at how these work.
@@ -45,7 +45,8 @@ Of course, these can be decoded again:
 base64.b64decode(encoded)
 ```
 
-Let us assume we have a `<data>` field that contains a number of bytes:
+Let us make use of these functions.
+Assume we have a `<data>` field that contains a number of bytes:
 
 ```{code-cell}
 :tags: ["remove-input"]
@@ -73,20 +74,47 @@ In a third step, we embed the `<item>` into a (binary) string:
 !grep '^<start>' encode.fan
 ```
 
-The resulting [`encode.fan`](encode.fan) spec allows us to encode and embed binary data:
+The full resulting [`encode.fan`](encode.fan) spec looks like this:
 
 ```{code-cell}
-!fandango fuzz -f encode.fan -n 1
+:tags: ["remove-input"]
+!cat encode.fan
+```
+
+With this, we can encode and embed binary data:
+
+```shell
+$ fandango fuzz -f encode.fan -n 1
+```
+
+```{code-cell}
+:tags: ["remove-input"]
+!fandango fuzz -f encode.fan -n 1 --random-seed 7
+assert _exit_code == 0
 ```
 
 In the same vein, one can use functions for compressing data or any other kind of conversion.
 
 
-## Decoding Parsed Data
+## Encoders and Constraints
+
+When Fandango produces an input using a generator, it _saves_ the generated arguments in the produced derivation tree.
+These become visible as soon as the input is shown as a grammar:
+
+```shell
+$ fandango fuzz -f encode.fan -n 1 --format=grammar
+```
 
 ```{code-cell}
-!echo -n 'Data: RmFuZGFuZ2+O' | fandango parse -f encode-decode.fan -o - --format=grammar
+:tags: ["remove-input"]
+!fandango fuzz -f encode.fan -n 1 --format=grammar --random-seed 7
+assert _exit_code == 0
 ```
+
+In the definition of `<item>`, we see a generator `f(<data>)` as well as the definition of `<data>` that went into the generator.
+(The actual generator code, `base64.b64encode(bytes(<data>))`, is not saved.)
+
+We can visualize the resulting tree, using a double arrow between `<data>` and `<item>`, indicating that their values depend on each other:
 
 ```{code-cell}
 :tags: ["remove-input"]
@@ -95,14 +123,153 @@ from Tree import Tree
 tree = Tree('<start>',
   Tree(b'Data: '),
   Tree('<item>',
-    Tree(b'RmFuZGFuZ2+O'),
+    Tree(b'RmFuZGFuZ29Nyhg='),
     sources=[
       Tree('<data>',
         Tree(b'Fandango'),
-        Tree('<byte>', Tree('<_byte>', Tree(b'\x8e')))
+        Tree('<byte>', Tree('<_byte>', Tree(b'M'))),
+        Tree('<byte>', Tree('<_byte>', Tree(b'\xca'))),
+        Tree('<byte>', Tree('<_byte>', Tree(b'\x18')))
       ),
     ]
   )
 )
 tree.visualize()
 ```
+
+Since arguments like `<data>` are preserved, we can use them in [constraints](sec:constraints).
+For instance, we can produce a string with specific values for `<data>`:
+
+```shell
+$ fandango fuzz -f encode.fan -n 1 -c '<data> == b"Fandango author"'
+```
+
+```{code-cell}
+:tags: ["remove-input"]
+!fandango fuzz -f encode.fan -n 1 -c '<data> == b"Fandango author"' --population-size 1
+assert _exit_code == 0
+```
+
+Is this string a correct encoding of a correct string?
+We will see in the next section.
+
+
+## Decoding Parsed Data
+
+So far, we can only _encode_ data during fuzzing.
+But what if we also want to _decode_ data, say during [parsing](sec:parsing)?
+Our `encode.fan` will help us _parse_ the data, but not decode it:
+
+```shell
+$ echo -n 'Data: RmFuZGFuZ28gYXV0aG9y' | fandango parse -f encode.fan
+```
+
+```{code-cell}
+:tags: ["remove-input"]
+!echo -n 'Data: RmFuZGFuZ28gYXV0aG9y' | fandango parse -f encode.fan
+assert _exit_code == 1
+```
+
+The fact that parsing fails is not a big surprise, as we only have specified an _encoder_, but not a _decoder_.
+As the error message suggests, we need to add a generator for `<data>` - a decoder that converts `<item>` elements into `<data>`.
+
+We can achieve this by providing a generator for `<data>` that builds on `<item>`:
+
+```{code-cell}
+:tags: ["remove-input"]
+!grep '^<data>' encode-decode.fan
+```
+
+Here, `base64.b64decode(bytes(<item>))` takes an `<item>` (which is previously parsed) and decodes it.
+The decoded result is parsed and placed in `<data>`.
+
+The resulting [`encode-decode.fan`](encode-decode.fan) file now looks like this:
+
+```{code-cell}
+:tags: ["remove-input"]
+!cat encode-decode.fan
+```
+
+```{margin}
+Fandango allows generators in both directions so one `.fan` file can be used for fuzzing and parsing.
+```
+
+If this looks like a mutual recursive definition, that is because it is.
+During fuzzing and parsing, Fandango tracks the _dependencies_ between generators and uses them to decide which generators to use first:
+
+* When fuzzing, Fandango operates _top-down_, starting with the topmost generator encountered; their arguments are _produced_.
+  In our case, this is the `<item>` generator, generating a value for `<data>`.
+* When parsing, Fandango operates _bottom-up_, starting with the lowest generators encountered; their arguments are _parsed_.
+  In our case, this is the `<data>` generator, parsing a value for `<item>`.
+
+In both case, when Fandango encounters a recursion, _it stops evaluating the generator_:
+
+* When parsing an `<item>`, Fandango does not invoke the generator for `<data>` because `<data>` is being processed already.
+* Likewise, when producing `<data>`, Fandango does not invoke the generator for `<item>` because `<item>` is being processed already.
+
+Let us see if all of this works and if this input is indeed properly parsed and decoded.
+
+```shell
+$ echo -n 'Data: RmFuZGFuZ28gYXV0aG9y' | fandango parse -f encode-decode.fan -o - --format=grammar
+```
+
+```{code-cell}
+:tags: ["remove-input"]
+!echo -n 'Data: RmFuZGFuZ28gYXV0aG9y' | fandango parse -f encode-decode.fan -o - --format=grammar
+assert _exit_code == 0
+```
+
+We see that the `<data>` element contains the `"Fandango author"` string we provided as a constraint during generation.
+This is what the parsed derivation tree looks like:
+
+```{code-cell}
+:tags: ["remove-input"]
+from Tree import Tree
+
+tree = Tree('<start>',
+  Tree(b'Data: '),
+  Tree('<item>',
+    Tree(b'RmFuZGFuZ28gYXV0aG9y'),
+    sources=[
+      Tree('<data>',
+        Tree(b'Fandango'),
+        Tree('<byte>', Tree('<_byte>', Tree(b' '))),
+        Tree('<byte>', Tree('<_byte>', Tree(b'a'))),
+        Tree('<byte>', Tree('<_byte>', Tree(b'u'))),
+        Tree('<byte>', Tree('<_byte>', Tree(b't'))),
+        Tree('<byte>', Tree('<_byte>', Tree(b'h'))),
+        Tree('<byte>', Tree('<_byte>', Tree(b'o'))),
+        Tree('<byte>', Tree('<_byte>', Tree(b'r')))
+      ),
+    ]
+  )
+)
+tree.visualize()
+```
+
+With a constraint, we can check that the decoded string is correct:
+
+```shell
+$ echo -n 'Data: RmFuZGFuZ28gYXV0aG9y' | fandango parse -f encode-decode.fan -c '<data> == b"Fandango author"'
+```
+
+```{code-cell}
+:tags: ["remove-input"]
+!echo -n 'Data: RmFuZGFuZ28gYXV0aG9y' | fandango parse -f encode-decode.fan -c '<data> == b"Fandango author"'
+assert _exit_code == 0
+```
+
+We get no error - so the parse was successful, and that all constraints hold.
+
+
+## Applications
+
+The above scheme can be used for all kinds of encodings and compressions - and thus allow _translations between abstraction layers_.
+Typical applications include:
+
+* _Compressed_ data (e.g. pixels in a GIF or PNG file)
+* _Encoded_ data (e.g. binary input as ASCII chars in MIME encodings)
+* _Converted_ data (e.g. ASCII to UTF-8 to UTF-16 and back)
+
+Even though parts of the input are encoded (or compressed), you can still use _constraints_ to shape them.
+And if the encoding or compression can be inverted, you can also use it to _parse_ inputs again.

--- a/docs/Conversion.md
+++ b/docs/Conversion.md
@@ -16,14 +16,16 @@ kernelspec:
 When defining a complex input format, some parts may be the result of applying an _operation_ on another, more structured part.
 Most importantly, content may be _encoded_, _compressed_, or _converted_.
 
-Fandango uses a special form of [generators](sec:generators) to handle these, namely generators with _symbols_.
+Fandango uses a special form of [generators](sec:generators) to handle these, called _converters_.
+These are generator expressions with _symbols_, mostly functions that take symbols as arguments.
 Let's have a look at how these work.
 
 
 ## Encoding Data During Fuzzing
 
 In Fandango, a [generator](sec:generators) expression can contain _symbols_ (enclosed in `<...>`) as elements.
-When fuzzing, this has the effect of Fandango using the grammar to
+Such generators are called _converters_.
+When fuzzing, converters have the effect of Fandango using the grammar to
 
 * instantiate each symbol from the grammar,
 * evaluate the resulting expression, and
@@ -96,10 +98,10 @@ assert _exit_code == 0
 In the same vein, one can use functions for compressing data or any other kind of conversion.
 
 
-## Encoders and Constraints
+## Sources, Encoders, and Constraints
 
-When Fandango produces an input using a generator, it _saves_ the generated arguments in the produced derivation tree.
-These become visible as soon as the input is shown as a grammar:
+When Fandango produces an input using a generator, it _saves_ the generated arguments as a _source_ in the produced derivation tree.
+Sources become visible as soon as the input is shown as a grammar:
 
 ```shell
 $ fandango fuzz -f encode.fan -n 1 --format=grammar
@@ -111,10 +113,10 @@ $ fandango fuzz -f encode.fan -n 1 --format=grammar
 assert _exit_code == 0
 ```
 
-In the definition of `<item>`, we see a generator `f(<data>)` as well as the definition of `<data>` that went into the generator.
-(The actual generator code, `base64.b64encode(bytes(<data>))`, is not saved.)
+In the definition of `<item>`, we see a generic converter `f(<data>)` as well as the definition of `<data>` that went into the generator.
+(The actual generator code, `base64.b64encode(bytes(<data>))`, is not saved in the derivation tree.)
 
-We can visualize the resulting tree, using a double arrow between `<data>` and `<item>`, indicating that their values depend on each other:
+We can visualize the resulting tree, using a double arrow between `<item>` and its source `<data>`, indicating that their values depend on each other:
 
 ```{code-cell}
 :tags: ["remove-input"]
@@ -137,7 +139,7 @@ tree = Tree('<start>',
 tree.visualize()
 ```
 
-Since arguments like `<data>` are preserved, we can use them in [constraints](sec:constraints).
+Since sources like `<data>` are preserved, we can use them in [constraints](sec:constraints).
 For instance, we can produce a string with specific values for `<data>`:
 
 ```shell

--- a/docs/DerivationTree.md
+++ b/docs/DerivationTree.md
@@ -181,7 +181,10 @@ Invoking methods (`<SYMBOL>.METHOD()`), as well as operators (say, `<SYMBOL> + .
 Since any `<SYMBOL>` has the type `DerivationTree`, one must convert it first into a standard Python type before passing it as argument to a standard Python function.
 
 `str(<SYMBOL>) -> str`
-: Convert `<SYMBOL>` into a Unicode string. If `<SYMBOL>` is a byte string, its contents are converted using `latin-1` encoding.
+: Convert `<SYMBOL>` into a Unicode string. Byte strings in `<SYMBOL>` are converted using `latin-1` encoding.
+
+`bytes(<SYMBOL>) -> bytes`
+: Convert `<SYMBOL>` into a byte string. Unicode strings in `<SYMBOL>` are converted using `utf-8` encoding.
 
 `int(<SYMBOL>) -> int`
 : Convert `<SYMBOL>` into an integer, like the Python `int()` function.
@@ -189,11 +192,11 @@ Since any `<SYMBOL>` has the type `DerivationTree`, one must convert it first in
 
 `float(<SYMBOL>) -> float`
 : Convert `<SYMBOL>` into a floating-point number, like the Python `float()` function.
-`<SYMBOL>` must be an int, or a Unicode string or byte string representing a float literal.
+`<SYMBOL>` must be an `int`, or a Unicode string or byte string representing a float literal.
 
 `complex(<SYMBOL>) -> complex`
 : Convert `<SYMBOL>` into a complex number, like the Python `complex()` function.
-`<SYMBOL>` must be an int, or a Unicode string or byte string representing a float literal.
+`<SYMBOL>` must be an `int`, or a Unicode string or byte string representing a float or complex literal.
 
 `bool(<SYMBOL>) -> bool`
 : Convert `<SYMBOL>` into a truth value:
@@ -274,6 +277,12 @@ Each element of the list can have a different type, depending on the type the `v
 
 `<SYMBOL>.parent() -> DerivationTree | None`
 : Return the parent of the current node, or `None` for the root node.
+
+
+### Accessing Sources
+
+`<SYMBOL>.sources() -> list[DerivationTree]`
+: Return a list containing all sources of `<SYMBOL>`. Sources are symbols used in generator expressions out of which the value of `<SYMBOL>` was created; see [the section on data conversions](sec:conversion) for details.
 
 
 ### Comparisons

--- a/docs/Tree.py
+++ b/docs/Tree.py
@@ -45,7 +45,7 @@ class Tree:
         if isinstance(self.symbol, int):
             color = "bisque4"
         elif isinstance(self.symbol, bytes):
-            color = "darkgray"
+            color = "gray25"
         elif self.symbol.startswith("<"):
             color = "firebrick"
         else:
@@ -61,6 +61,6 @@ class Tree:
 
         for source in self.sources():
             source_name = source._visualize()
-            Tree.dot.edge(name, source_name, style="dotted", color="gray")
+            Tree.dot.edge(name, source_name, style="dotted", color="gray", dir="both")
 
         return name

--- a/docs/Tree.py
+++ b/docs/Tree.py
@@ -42,14 +42,15 @@ class Tree:
             label = repr(self.symbol)
 
         # https://graphviz.org/doc/info/colors.html
+        # Colors checked against color vision deficiency
         if isinstance(self.symbol, int):
             color = "bisque4"
         elif isinstance(self.symbol, bytes):
-            color = "gray25"
+            color = "darkblue"
         elif self.symbol.startswith("<"):
             color = "firebrick"
         else:
-            color = "darkblue"
+            color = "olivedrab4"
 
         label = label.replace("<", "\\<")
         label = label.replace(">", "\\>")

--- a/docs/Tree.py
+++ b/docs/Tree.py
@@ -36,14 +36,16 @@ class Tree:
     def _visualize(self):
         name = f"node-{Tree.id_counter}"
         Tree.id_counter += 1
-        if isinstance(self.symbol, int):
-            label = str(self.symbol)
-        else:
+        if str(self.symbol).startswith("<"):
             label = self.symbol
+        else:
+            label = repr(self.symbol)
 
         # https://graphviz.org/doc/info/colors.html
         if isinstance(self.symbol, int):
             color = "bisque4"
+        elif isinstance(self.symbol, bytes):
+            color = "darkgray"
         elif self.symbol.startswith("<"):
             color = "firebrick"
         else:
@@ -59,6 +61,6 @@ class Tree:
 
         for source in self.sources():
             source_name = source._visualize()
-            Tree.dot.edge(name, source_name)
+            Tree.dot.edge(name, source_name, style="dotted", color="gray")
 
         return name

--- a/evaluation/experiments/generator_params/generator_params.fan
+++ b/evaluation/experiments/generator_params/generator_params.fan
@@ -5,8 +5,8 @@ def un_convert(input):
     return input[::-1]
 
 <start> ::= <number> <rev_number>
-<rev_number> ::= <number_tail>{0, 2} <number_start> :: convert(<source_number>.to_string())
-<source_number> ::= <number> :: un_convert(<rev_number>.to_string())
+<rev_number> ::= <number_tail>{0, 2} <number_start> := convert(<source_number>.to_string())
+<source_number> ::= <number> := un_convert(<rev_number>.to_string())
 
 <number> ::= <number_start> <number_tail>{0, 2}
 <number_start> ::= '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'

--- a/evaluation/experiments/generator_params/generator_params.py
+++ b/evaluation/experiments/generator_params/generator_params.py
@@ -5,11 +5,11 @@ from fandango.language.tree import DerivationTree
 
 def count_g_params(tree: DerivationTree):
     count = 0
-    if len(tree.generator_params) > 0:
+    if len(tree.sources) > 0:
         count += 1
     for child in tree.children:
         count += count_g_params(child)
-    for child in tree.generator_params:
+    for child in tree.sources:
         count += count_g_params(child)
     return count
 

--- a/evaluation/experiments/transactions/transactions.fan
+++ b/evaluation/experiments/transactions/transactions.fan
@@ -15,13 +15,13 @@ def compute_end_balance_sender(start_balance, amount):
 <info> ::= '   <info>\n' <currency> <stmt_date> <amount>'   </info>'
 <currency> ::= '      <currency>' 'EUR' '</currency>\n' | '      <currency>' 'USD' '</currency>\n'
 <stmt_date> ::= '      <stmt_date>' <timestamp> '</stmt_date>\n'
-<timestamp> ::= <digit>+ :: str(int(time.time()))
+<timestamp> ::= <digit>+ := str(int(time.time()))
 <amount> ::= '      <amount>' <am> '</amount>\n'
 <am> ::= <digit>+ ;
 <sender> ::= '\n   <sender>' <name> <account_no> <bank_key> <start_balance> <end_balance> '   </sender>'
 <receiver> ::= '\n   <receiver>' <name> <account_no> <bank_key> <start_balance> <end_balance> '   </receiver>\n'
 <name> ::= '\n      <name>' <name_str> '</name>'
-<name_str> ::= <letter>* :: str(fake.name()).upper();
+<name_str> ::= <letter>* := str(fake.name()).upper();
 <account_no> ::= '\n      <account_no>' <account_number> '</account_no>\n'
 <account_number> ::= <digit><digit><digit><digit><digit> <digit><digit><digit><digit><digit> <digit><digit><digit><digit><digit> <digit><digit><digit><digit><digit> <digit><digit>
 <bank_key> ::= '      <bank_key>' <bank_id> '</bank_key>\n'

--- a/evaluation/vs_isla/tar_evaluation/tar.fan
+++ b/evaluation/vs_isla/tar_evaluation/tar.fan
@@ -21,7 +21,7 @@
     <file_name_prefix>
     <header_padding>
 ;
-<file_name> ::= <file_name_first_char> <file_name_chars> <NULs> :: generate_file_name() ;
+<file_name> ::= <file_name_first_char> <file_name_chars> <NULs> := generate_file_name() ;
 <file_name_chars> ::= <file_name_char> <file_name_chars> | "" ;
 <NULs> ::= <NUL> <NULs> | "" ;
 <file_mode> ::= <octal_digit>{6} <SPACE> <NUL>;
@@ -31,10 +31,10 @@
 <mod_time> ::= <octal_digit>{11} <SPACE>;
 <checksum> ::= <octal_digit>{6} <NUL> <SPACE> ;
 <typeflag> ::= '0' ;
-<linked_file_name> ::= <file_name_first_char> <file_name_char_or_nul>{99} | <NUL>{100} :: generate_linked_file_name();
+<linked_file_name> ::= <file_name_first_char> <file_name_char_or_nul>{99} | <NUL>{100} := generate_linked_file_name();
 <file_name_char_or_nul> ::= <file_name_char> | <NUL> ;
-<uname> ::= <uname_first_char> <name_char_dollar_nul>{31} :: generate_uname("<uname>") ;
-<gname> ::= <uname_first_char> <name_char_dollar_nul>{31} :: generate_uname("<gname>") ;
+<uname> ::= <uname_first_char> <name_char_dollar_nul>{31} := generate_uname("<uname>") ;
+<gname> ::= <uname_first_char> <name_char_dollar_nul>{31} := generate_uname("<gname>") ;
 <name_char_dollar_nul> ::= <uname_char> | '$' | <NUL> ;
 <uname_first_char> ::=
     'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm'
@@ -49,7 +49,7 @@
 <dev_min_num> ::= <octal_digit>{6} <SPACE> <NUL> ;
 <file_name_prefix> ::= <NUL>{155};
 <header_padding> ::= <NUL>{12};
-<content> ::= <char_or_nul>{512} :: generate_content() ;
+<content> ::= <char_or_nul>{512} := generate_content() ;
 <char_or_nul> ::= <character> | <NUL> ;
 <final_entry> ::= <NUL>{1024};
 <octal_digit> ::= '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' ;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fandango-fuzzer"
-version = "0.1.8"
+version = "0.2.0"
 authors = [
     { name = "José Antonio Zamudio Amaya", email = "jose.zamudio@cispa.de" },
     { name = "Marius Smytzek", email = "marius.smytzek@cispa.de" },

--- a/src/fandango/__init__.py
+++ b/src/fandango/__init__.py
@@ -214,7 +214,7 @@ class Fandango(FandangoBase):
         )
         try:
             peek = next(tree_generator)
-            self.grammar.populate_generator_params(peek)
+            self.grammar.populate_sources(peek)
             tree_generator = itertools.chain([peek], tree_generator)
             have_tree = True
         except StopIteration:

--- a/src/fandango/__init__.py
+++ b/src/fandango/__init__.py
@@ -20,9 +20,14 @@ class FandangoError(ValueError):
 class FandangoParseError(FandangoError, SyntaxError):
     """Error during parsing inputs"""
 
-    def __init__(self, position: int, *, message: str = None):
+    def __init__(self, message: str | None = None, position: int | None = None):
         if message is None:
-            message = f"Parse error at position {position}"
+            if position is not None:
+                message = f"Parse error at position {position}"
+            else:
+                message = "Parse error"
+
+        # Call the parent class constructors
         FandangoError.__init__(self, message)
         SyntaxError.__init__(self, message)
         self.position = position
@@ -222,7 +227,7 @@ class Fandango(FandangoBase):
 
         if not have_tree:
             position = self.grammar.max_position() + 1
-            raise FandangoParseError(position)
+            raise FandangoParseError(position=position)
 
         return tree_generator
 

--- a/src/fandango/cli/__init__.py
+++ b/src/fandango/cli/__init__.py
@@ -934,7 +934,7 @@ def parse_file(fd, args, grammar, constraints, settings):
     while tree := next(tree_gen, None):
         LOGGER.debug(f"Checking parse alternative #{alternative_counter}")
         last_tree = tree
-        grammar.populate_generator_params(last_tree)
+        grammar.populate_sources(last_tree)
 
         passed = True
         for constraint in constraints:

--- a/src/fandango/evolution/algorithm.py
+++ b/src/fandango/evolution/algorithm.py
@@ -126,8 +126,8 @@ class Fandango:
                     if not tree:
                         position = self.grammar.max_position()
                         raise FandangoParseError(
-                            position,
                             message=f"Failed to parse initial individual{individual!r}",
+                            position=position
                         )
                 elif isinstance(individual, DerivationTree):
                     tree = individual

--- a/src/fandango/language/grammar.py
+++ b/src/fandango/language/grammar.py
@@ -725,10 +725,15 @@ class Grammar(NodeVisitor):
             self,
             symbol: Symbol,
             children: Optional[List["DerivationTree"]] = None,
+            *,
             parent: Optional["DerivationTree"] = None,
             read_only: bool = False,
         ):
-            super().__init__(symbol, children, parent, [], read_only)
+            super().__init__(symbol,
+                             children,
+                             parent=parent,
+                             sources=[],
+                             read_only=read_only)
 
         def set_children(self, children: List["DerivationTree"]):
             self._children = children
@@ -1158,9 +1163,9 @@ class Grammar(NodeVisitor):
                     DerivationTree(
                         child.symbol,
                         children,
-                        child.parent,
-                        child.sources,
-                        child.read_only,
+                        parent=child.parent,
+                        sources=child.sources,
+                        read_only=child.read_only,
                     )
                 )
             return ret
@@ -1170,9 +1175,9 @@ class Grammar(NodeVisitor):
             return DerivationTree(
                 tree.symbol,
                 children,
-                tree.parent,
-                tree.sources,
-                tree.read_only,
+                parent=tree.parent,
+                sources=tree.sources,
+                read_only=tree.read_only,
             )
 
         def complete(

--- a/src/fandango/language/parse.py
+++ b/src/fandango/language/parse.py
@@ -16,7 +16,6 @@ import dill as pickle
 
 from antlr4 import CommonTokenStream, InputStream
 from antlr4.error.ErrorListener import ErrorListener
-from thefuzz import process as thefuzz_process
 from xdg_base_dirs import xdg_cache_home, xdg_data_dirs, xdg_data_home
 
 from fandango.constraints import predicates
@@ -26,7 +25,7 @@ from fandango.language.convert import (
     GrammarProcessor,
     PythonProcessor,
 )
-from fandango.language.grammar import Grammar, NodeType, MAX_REPETITIONS
+from fandango.language.grammar import Grammar, NodeType, MAX_REPETITIONS, closest_match
 from fandango.language.parser.FandangoLexer import FandangoLexer
 from fandango.language.parser.FandangoParser import FandangoParser
 from fandango.language.stdlib import stdlib
@@ -52,13 +51,6 @@ class MyErrorListener(ErrorListener):
         exc.messsage = msg
         raise exc
 
-
-def closest_match(word, candidates):
-    """
-    `word` raises a syntax error;
-    return alternate suggestion for `word` from `candidates`
-    """
-    return thefuzz_process.extractOne(word, candidates)[0]
 
 
 ### Including Files

--- a/src/fandango/language/tree.py
+++ b/src/fandango/language/tree.py
@@ -16,16 +16,25 @@ class DerivationTree:
         self,
         symbol: Symbol,
         children: Optional[List["DerivationTree"]] = None,
+        *,
         parent: Optional["DerivationTree"] = None,
         sources: list["DerivationTree"] = None,
         read_only: bool = False,
     ):
+        """
+        Create a new derivation tree node.
+        :param symbol: The symbol for this node (type Symbol)
+        :param children: The children of this node (a list of DerivationTree)
+        :param parent: (optional) The parent of this node (a DerivationTree node)
+        :param sources: (optional) The sources of this node (a list of DerivationTrees used in generators to produce this node)
+        :param read_only: If True, the node is read-only and cannot be modified (default: False)
+        """
         if not isinstance(symbol, Symbol):
             raise TypeError(f"Expected Symbol, got {type(symbol)}")
 
         self.hash_cache = None
         self._parent: Optional["DerivationTree"] = parent
-        self.symbol: Symbol = symbol
+        self._symbol: Symbol = symbol
         self._children: list["DerivationTree"] = []
         self._sources: list["DerivationTree"] = []
         if sources is not None:
@@ -33,6 +42,7 @@ class DerivationTree:
         self.read_only = read_only
         self._size = 1
         self.set_children(children or [])
+        self.invalidate_hash()
 
     def __len__(self):
         return len(self._children)

--- a/tests/resources/dynamic_repetition.fan
+++ b/tests/resources/dynamic_repetition.fan
@@ -2,7 +2,7 @@ from struct import unpack
 import random
 
 <start> ::= <len> '(' <inner>{int(<len>)} ')'
-<len> ::= <number> :: str(random.randrange(1, 4))
+<len> ::= <number> := str(random.randrange(1, 4))
 <inner> ::= <len> <letter>{int(<len>)}
 <letter> ::= r'[a-zA-Z]'
 

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -14,11 +14,11 @@ class ConstraintTest(unittest.TestCase):
 
     def count_g_params(self, tree: DerivationTree):
         count = 0
-        if len(tree.generator_params) > 0:
+        if len(tree.sources) > 0:
             count += 1
         for child in tree.children:
             count += self.count_g_params(child)
-        for child in tree.generator_params:
+        for child in tree.sources:
             count += self.count_g_params(child)
         return count
 
@@ -69,13 +69,13 @@ class ConstraintTest(unittest.TestCase):
 
         for solution in self.get_solutions(grammar, c):
             self.assertEqual(self.count_g_params(solution), 4)
-            converted_inner = solution.children[0].generator_params[0]
+            converted_inner = solution.children[0].sources[0]
             self.assertEqual(self.count_g_params(converted_inner), 3)
-            dummy_inner_2 = converted_inner.children[0].generator_params[0]
+            dummy_inner_2 = converted_inner.children[0].sources[0]
             self.assertEqual(self.count_g_params(dummy_inner_2), 2)
-            dummy_inner = dummy_inner_2.children[0].generator_params[0]
+            dummy_inner = dummy_inner_2.children[0].sources[0]
             self.assertEqual(self.count_g_params(dummy_inner), 1)
-            source_nr = dummy_inner.children[0].children[1].generator_params[0]
+            source_nr = dummy_inner.children[0].children[1].sources[0]
             self.assertEqual(self.count_g_params(source_nr), 0)
 
     def test_repetitions(self):


### PR DESCRIPTION
This pull request brings

* Extended documentation for converter functions (generators with symbol parameters)
* Code cleanup: `DerivationTree` now requires keyword arguments for parent, sources, read_only
* Code cleanup: Improved error messages for parsing and consistency errors
* Global rename of `generator_params` to `sources`