### PR TITLE
Make Fandango deterministic

### DIFF
--- a/src/fandango/evolution/algorithm.py
+++ b/src/fandango/evolution/algorithm.py
@@ -330,9 +330,7 @@ class Fandango:
 
             if self.profiling:
                 self.profiler.start_timer("evaluate_population")
-            self.evaluation = self.evaluator.evaluate_population_parallel(
-                self.population, num_workers=4
-            )
+            self.evaluation = self.evaluator.evaluate_population(self.population)
             if self.profiling:
                 self.profiler.stop_timer("evaluate_population")
                 self.profiler.increment("evaluate_population", len(self.population))

--- a/src/fandango/evolution/crossover.py
+++ b/src/fandango/evolution/crossover.py
@@ -24,7 +24,7 @@ class SimpleSubtreeCrossover(CrossoverOperator):
         common_symbols = symbols1.intersection(symbols2)
         if not common_symbols:
             return parent1, parent2
-        symbol = random.choice(list(common_symbols))
+        symbol = random.choice(sorted(list(common_symbols)))
         nodes1 = parent1.find_all_nodes(symbol)
         nodes2 = parent2.find_all_nodes(symbol)
         node1 = random.choice(nodes1)

--- a/src/fandango/language/symbol.py
+++ b/src/fandango/language/symbol.py
@@ -66,6 +66,10 @@ class NonTerminal(Symbol):
     def __eq__(self, other):
         return isinstance(other, NonTerminal) and self.symbol == other.symbol
 
+    def __lt__(self, other):
+        if isinstance(other, NonTerminal):
+            return self.symbol < other.symbol
+
     def __hash__(self):
         return hash((self.symbol, self.type))
 

--- a/tests/resources/determinism.fan
+++ b/tests/resources/determinism.fan
@@ -1,0 +1,14 @@
+# fandango fuzz -f tests/resources/determinism.fan -n 10 --random-seed 1
+
+<start> ::= <sub>
+<sub>   ::= <a> "-" <b>
+<number> ::= <leadingdigit> | <leadingdigit> <digits>
+<leadingdigit> ::= "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+<digit> ::= "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+<digits> ::= <digit> <digits> | <digit>
+<a>     ::= <number>
+<b>     ::= <number>
+
+where str(<a>) == str(<b>)
+where int(str(<a>)) < 1000000
+where int(str(<b>)) >  500000

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -178,5 +178,33 @@ class GeneticTest(unittest.TestCase):
             self.assertTrue(self.fandango.grammar.parse(str(individual)))
 
 
+class DeterminismTests(unittest.TestCase):
+    # fandango fuzz -f tests/resources/determinism.fan -n 100 --random-seed 1
+    def get_solutions(self, specification_file, desired_solutions, random_seed,):
+        file = open(specification_file, "r")
+        grammar_int, constraints_int = parse(
+            file, use_stdlib=False, use_cache=False
+        )
+        fandango = Fandango(
+            grammar=grammar_int,
+            constraints=constraints_int,
+            desired_solutions=desired_solutions,
+            random_seed=random_seed
+        )
+        solutions: List[DerivationTree] = fandango.evolve()
+        return [s.to_string() for s in solutions]
+
+    def test_deterministic_solutions(self):
+        solutions_1 = self.get_solutions(
+            "tests/resources/determinism.fan", 100, 1
+        )
+
+        solutions_2 = self.get_solutions(
+            "tests/resources/determinism.fan", 100, 1
+        )
+
+        self.assertListEqual(solutions_1, solutions_2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Even with a fixed random seed, Fandango may produce different results.

This has two causes:
- Unordered sets seem to introduce non-determinism.
- `evaluate_population_parallel` seems to introduce non-determinism. I benchmarked this swiftly, and in my case `evaluate_population` was even faster (0.02 sec vs 0.03 sec)

This PR makes Fandango generate deterministic results for a given random seed.
