### PR TITLE
Allow fine-grained mutations in a subtree of the "failing tree"

### DIFF
--- a/src/fandango/evolution/mutation.py
+++ b/src/fandango/evolution/mutation.py
@@ -76,5 +76,3 @@ class SimpleMutation(MutationOperator):
         )
         mutated = individual.replace(grammar, node_to_mutate, new_subtree)
         return mutated
-
-        return individual

--- a/src/fandango/evolution/mutation.py
+++ b/src/fandango/evolution/mutation.py
@@ -43,7 +43,12 @@ class SimpleMutation(MutationOperator):
 
         # Collect the failing subtrees
         failing_subtrees = [ft.tree for ft in failing_trees]
-        failing_subtrees = list(filter(lambda x: not x.read_only, failing_subtrees))
+        failing_subtrees = list(
+            filter(
+                lambda x: (not x.read_only) and (x.symbol.is_non_terminal),
+                failing_subtrees,
+            )
+        )
 
         # If there is nothing to mutate, return the individual as is.
         if not failing_subtrees:
@@ -51,20 +56,25 @@ class SimpleMutation(MutationOperator):
 
         # Randomly choose one failing subtree for mutation.
         node_to_mutate = random.choice(failing_subtrees)
-
-        # If the symbol of the node is non-terminal, fuzz a new subtree and perform the replacement.
-        if node_to_mutate.symbol.is_non_terminal:
-            # Get a truncated tree that contains all nodes left from the selected node.
-            ctx_tree = node_to_mutate.split_end()
-            if ctx_tree.parent is not None:
-                ctx_tree = ctx_tree.parent
-                ctx_tree.set_children(ctx_tree.children[:-1])
-            else:
-                ctx_tree = None
-            new_subtree = grammar.fuzz(
-                node_to_mutate.symbol, prefix_node=ctx_tree, max_nodes=max_nodes
+        subtrees = [node_to_mutate] + list(
+            filter(
+                lambda x: (not x.read_only) and (x.symbol.is_non_terminal),
+                node_to_mutate.descendants(),
             )
-            mutated = individual.replace(grammar, node_to_mutate, new_subtree)
-            return mutated
+        )
+        node_to_mutate = random.choice(subtrees)
+
+        # Get a truncated tree that contains all nodes left from the selected node.
+        ctx_tree = node_to_mutate.split_end()
+        if ctx_tree.parent is not None:
+            ctx_tree = ctx_tree.parent
+            ctx_tree.set_children(ctx_tree.children[:-1])
+        else:
+            ctx_tree = None
+        new_subtree = grammar.fuzz(
+            node_to_mutate.symbol, prefix_node=ctx_tree, max_nodes=max_nodes
+        )
+        mutated = individual.replace(grammar, node_to_mutate, new_subtree)
+        return mutated
 
         return individual

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,7 +128,7 @@ fandango:ERROR: Only found 0 perfect solutions, instead of the required 10
 
     def test_max_nodes_unsat(self):
         command = shlex.split(
-            "fandango fuzz -f tests/resources/gen_number.fan  -n 10 --population-size 10 --max-generations 50 --no-cache -c 'len(str(<start>)) > 60' --max-nodes 50"
+            "fandango fuzz -f tests/resources/gen_number.fan  -n 10 --population-size 10 --max-generations 30 --no-cache -c 'len(str(<start>)) > 60' --max-nodes 30"
         )
         expected = """fandango:ERROR: Population did not converge to a perfect population
 fandango:ERROR: Only found 0 perfect solutions, instead of the required 10


### PR DESCRIPTION
This also fixes an UNSAT test case, which could now be solved.

Related issue: #413 