### PR TITLE
Remove duplicate docs section with missing information

### DIFF
--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -54,25 +54,4 @@ assert _exit_code == 0
 This will get you the very latest version of Fandango, which may be unstable. Use at your own risk.
 ```
 
-% ```{note}
-% At this point, only registered developers have access to Fandango.
-% ```
-
-Clone the Fandango repository:
-
-```shell
-$ git clone https://github.com/fandango-fuzzer/fandango/
-```
-
-Switch to the top-level `fandango/` folder:
-
-```shell
-$ cd fandango
-```
-
-Run
-```shell
-$ pip install -e .
-```
-
-You should then be able to invoke Fandango as described above.
+Refer to the [Getting Started with Development Guide](sec:getting-started-with-development) for instructions on how to prepare an environment to work on Fandango.


### PR DESCRIPTION
There are two sets of instructions on how to set up a development environment in the docs — but one is missing important information (e.g. how to install dev dependencies). So I removed the incomplete version and added a link to the complete one instead.