### PR TITLE
Targeted mutations and fixes

### DIFF
--- a/src/fandango/evolution/adaptation.py
+++ b/src/fandango/evolution/adaptation.py
@@ -63,7 +63,7 @@ class AdaptiveTuner:
 
         # Adaptive Crossover
         if avg_diversity < diversity_low_threshold:
-            new_crossover_rate = min(1.0, self.crossover_rate * 1.05)
+            new_crossover_rate = min(0.9, self.crossover_rate * 1.05)
             LOGGER.info(
                 f"Generation {generation}: Increasing crossover rate from {self.crossover_rate:.2f} to {new_crossover_rate:.2f}"
             )

--- a/src/fandango/evolution/crossover.py
+++ b/src/fandango/evolution/crossover.py
@@ -29,6 +29,6 @@ class SimpleSubtreeCrossover(CrossoverOperator):
         nodes2 = parent2.find_all_nodes(symbol)
         node1 = random.choice(nodes1)
         node2 = random.choice(nodes2)
-        child1 = parent1.replace(grammar, node1, copy.deepcopy(node2))
-        child2 = parent2.replace(grammar, node2, copy.deepcopy(node1))
+        child1 = parent1.replace(grammar, node1, node2)
+        child2 = parent2.replace(grammar, node2, node1)
         return child1, child2

--- a/src/fandango/evolution/evaluation.py
+++ b/src/fandango/evolution/evaluation.py
@@ -196,9 +196,9 @@ class Evaluator:
         evaluation: List[Tuple[DerivationTree, float, List]],
         elitism_rate: float,
         population_size: int,
-    ) -> List[DerivationTree]:
+    ) -> List[Tuple[DerivationTree, float, List]]:
         return [
-            x[0]
+            x
             for x in sorted(evaluation, key=lambda x: x[1], reverse=True)[
                 : int(elitism_rate * population_size)
             ]
@@ -207,7 +207,7 @@ class Evaluator:
     def tournament_selection(
         self, evaluation: List[Tuple[DerivationTree, float, List]], tournament_size: int
     ) -> Tuple[DerivationTree, DerivationTree]:
-        tournament = random.sample(evaluation, k=tournament_size)
+        tournament = random.sample(evaluation, k=min(tournament_size, len(evaluation)))
         tournament.sort(key=lambda x: x[1], reverse=True)
         parent1 = tournament[0][0]
         if len(tournament) == 2:

--- a/src/fandango/language/tree.py
+++ b/src/fandango/language/tree.py
@@ -547,7 +547,7 @@ class DerivationTree:
         """
         Replace the subtree rooted at the given node with the new subtree.
         """
-        if self == tree_to_replace and not self.read_only:
+        if self is tree_to_replace:
             new_subtree = deepcopy(new_subtree)
             new_subtree._parent = self.parent
             grammar.populate_sources(new_subtree)
@@ -652,7 +652,7 @@ class DerivationTree:
 
     def flatten(self):
         """
-        Flatten the derivation tree into a list of symbols.
+        Flatten the derivation tree into a list of DerivationTrees.
         """
         flat = [self]
         for child in self._children:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -84,7 +84,7 @@ class test_cli(unittest.TestCase):
 
     def test_unsat(self):
         command = shlex.split(
-            "fandango fuzz -f tests/resources/digit.fan -n 10 --random-seed 426912 -c False"
+            "fandango fuzz -f tests/resources/digit.fan -n 10 -N 10 --random-seed 426912 -c False"
         )
         expected = """fandango:ERROR: Population did not converge to a perfect population
 fandango:ERROR: Only found 0 perfect solutions, instead of the required 10

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -77,18 +77,6 @@ class GeneticTest(unittest.TestCase):
         for individual in self.fandango.population:
             self.assertTrue(self.fandango.grammar.parse(str(individual)))
 
-    def test_select_elites(self):
-        # Select the elites
-        elites = self.fandango.select_elites()
-
-        self.assertEqual(
-            len(elites), self.fandango.elitism_rate * self.fandango.population_size
-        )
-
-        # Check that the population is valid
-        for individual in elites:
-            self.assertTrue(self.fandango.grammar.parse(str(individual)))
-
     def test_selection(self):
         # Select the parents
         parent1, parent2 = self.fandango.evaluator.tournament_selection(


### PR DESCRIPTION
- Enable targeted mutations. Previously, all instances of a given subtree were replaced by a mutation.
Targeted mutations are implemented as follows: We map derivation trees that are equal by value to the same reference using a dictionary. For instance, crossover or mutation may produce a new derivation tree (with a new reference) which was seen previously (with a different reference) and for which failing trees were already cached (by value, but mapping to a reference). Failing trees are required for targeted mutations. DerivationTree currently does not allow to uniquely identify nodes in a tree, e.g., by a path. Using unique references, we can now compare failing (sub-)trees with the current tree.
- Avoid 100% crossover rate because populations may have too little diversity to fill the population leading to a potential infinite loop.
- Fix a bug where `self.evaluation` was not updated to reflect the elite selection.
- Minor fixes

#424 