### PR TITLE
Add docs, remove duplicate code, improve separation of responsibilities, fix types

### DIFF
--- a/evaluation/vs_isla/csv_evaluation/csv_evaluation.py
+++ b/evaluation/vs_isla/csv_evaluation/csv_evaluation.py
@@ -1,7 +1,7 @@
 import csv
 import time
 from io import StringIO
-from typing import Tuple
+
 
 from fandango.evolution.algorithm import Fandango, LoggerLevel
 from fandango.language.parse import parse
@@ -28,7 +28,7 @@ def is_syntactically_valid_csv(csv_string):
 
 def evaluate_csv(
     seconds=60,
-) -> Tuple[str, int, int, float, Tuple[float, int, int], float, float]:
+) -> tuple[str, int, int, float, tuple[float, int, int], float, float]:
     file = open("evaluation/vs_isla/csv_evaluation/csv.fan", "r")
     grammar, constraints = parse(file, use_stdlib=False)
     solutions = []

--- a/evaluation/vs_isla/rest_evaluation/rest_evaluation.py
+++ b/evaluation/vs_isla/rest_evaluation/rest_evaluation.py
@@ -1,6 +1,6 @@
 import time
 from io import StringIO
-from typing import Tuple
+
 
 from docutils.core import publish_doctree
 
@@ -32,7 +32,7 @@ def is_syntactically_valid_rest(rst_string):
 
 def evaluate_rest(
     seconds=60,
-) -> Tuple[str, int, int, float, Tuple[float, int, int], float, float]:
+) -> tuple[str, int, int, float, tuple[float, int, int], float, float]:
     file = open("evaluation/vs_isla/rest_evaluation/rest.fan", "r")
     grammar, constraints = parse(file, use_stdlib=False)
     solutions = []

--- a/evaluation/vs_isla/run_evaluation.py
+++ b/evaluation/vs_isla/run_evaluation.py
@@ -1,7 +1,7 @@
 import logging
 import random
 import sys
-from typing import Tuple
+
 
 from evaluation.vs_isla.csv_evaluation.csv_evaluation import evaluate_csv
 from evaluation.vs_isla.rest_evaluation.rest_evaluation import evaluate_rest
@@ -17,7 +17,7 @@ LOGGER.setLevel(logging.WARNING)  # Default
 
 # Return the evaluation results as a tuple of values (subject, total, valid, percentage, diversity, mean_length, median)
 def better_print_results(
-    results: Tuple[str, int, int, float, Tuple[float, int, int], float, float],
+    results: tuple[str, int, int, float, tuple[float, int, int], float, float],
 ):
     print("================================")
     print(f"{results[0]} Evaluation Results")

--- a/evaluation/vs_isla/scriptsizec_evaluation/scriptsizec_evaluation.py
+++ b/evaluation/vs_isla/scriptsizec_evaluation/scriptsizec_evaluation.py
@@ -3,7 +3,7 @@ import shutil
 import subprocess
 import tempfile
 import time
-from typing import Tuple
+
 
 from tccbox import tcc_bin_path
 
@@ -83,7 +83,7 @@ def is_valid_tinyc_code(c_code: str) -> bool:
 
 def evaluate_scriptsizec(
     seconds=60,
-) -> Tuple[str, int, int, float, Tuple[float, int, int], float, float]:
+) -> tuple[str, int, int, float, tuple[float, int, int], float, float]:
     file = open("evaluation/vs_isla/scriptsizec_evaluation/scriptsizec.fan", "r")
     grammar, constraints = parse(file, use_stdlib=False)
     solutions = []

--- a/evaluation/vs_isla/tar_evaluation/tar_evaluation.py
+++ b/evaluation/vs_isla/tar_evaluation/tar_evaluation.py
@@ -1,7 +1,7 @@
 import subprocess
 import tempfile
 import time
-from typing import Tuple
+
 
 from fandango.evolution.algorithm import Fandango, LoggerLevel
 from fandango.language.parse import parse
@@ -24,7 +24,7 @@ def is_syntactically_valid_tar(tree: str):
 
 def evaluate_tar(
     seconds=60,
-) -> Tuple[str, int, int, float, Tuple[float, int, int], float, float]:
+) -> tuple[str, int, int, float, tuple[float, int, int], float, float]:
     file = open("evaluation/vs_isla/tar_evaluation/tar.fan", "r")
     grammar, constraints = parse(file, use_stdlib=False)
     solutions = []

--- a/evaluation/vs_isla/xml_evaluation/xml_evaluation.py
+++ b/evaluation/vs_isla/xml_evaluation/xml_evaluation.py
@@ -1,6 +1,6 @@
 import time
 import xml.etree.ElementTree as ET
-from typing import Tuple
+
 
 from fandango.evolution.algorithm import Fandango, LoggerLevel
 from fandango.language.parse import parse
@@ -18,7 +18,7 @@ def is_syntactically_valid_xml(xml_string):
 
 def evaluate_xml(
     seconds=60,
-) -> Tuple[str, int, int, float, Tuple[float, int, int], float, float]:
+) -> tuple[str, int, int, float, tuple[float, int, int], float, float]:
     file = open("evaluation/vs_isla/xml_evaluation/xml.fan", "r")
     grammar, constraints = parse(file, use_stdlib=False)
     solutions = []

--- a/src/fandango/__init__.py
+++ b/src/fandango/__init__.py
@@ -76,7 +76,7 @@ def homepage():
 
 
 from abc import ABC, abstractmethod
-from typing import IO, List, Optional, Generator
+from typing import IO, Optional, Generator
 import sys
 import logging
 
@@ -95,15 +95,15 @@ class FandangoBase(ABC):
 
     def __init__(
         self,
-        fan_files: str | IO | List[str | IO],
-        constraints: List[str] = None,
+        fan_files: str | IO | list[str | IO],
+        constraints: Optional[list[str]] = None,
         *,
         logging_level: Optional[int] = None,
         use_cache: bool = True,
         use_stdlib: bool = True,
         lazy: bool = False,
         start_symbol: Optional[str] = None,
-        includes: List[str] = None,
+        includes: Optional[list[str]] = None,
     ):
         """
         Initialize a Fandango object.
@@ -169,8 +169,8 @@ class FandangoBase(ABC):
 
     @abstractmethod
     def fuzz(
-        self, *, extra_constraints: Optional[List[str]] = None, **settings
-    ) -> List[DerivationTree]:
+        self, *, extra_constraints: Optional[list[str]] = None, **settings
+    ) -> list[DerivationTree]:
         """
         Create a Fandango population.
         :param extra_constraints: Additional constraints to apply
@@ -200,8 +200,8 @@ class Fandango(FandangoBase):
         super().__init__(*args, **kwargs)
 
     def fuzz(
-        self, *, extra_constraints: Optional[List[str]] = None, **settings
-    ) -> List[DerivationTree]:
+        self, *, extra_constraints: Optional[list[str]] = None, **settings
+    ) -> list[DerivationTree]:
         """
         Create a Fandango population.
         :param extra_constraints: Additional constraints to apply

--- a/src/fandango/_version.py
+++ b/src/fandango/_version.py
@@ -2,9 +2,9 @@
 # don't change, don't track in version control
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from typing import Tuple, Union
+    from typing import Union
 
-    VERSION_TUPLE = Tuple[Union[int, str], ...]
+    VERSION_TUPLE = tuple[Union[int, str], ...]
 else:
     VERSION_TUPLE = object
 

--- a/src/fandango/constraints/base.py
+++ b/src/fandango/constraints/base.py
@@ -5,7 +5,7 @@ This module contains the base classes for constraints in the fandango library.
 import itertools
 from abc import ABC, abstractmethod
 from copy import copy
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
 from tdigest import TDigest
 import math
 
@@ -558,11 +558,11 @@ class ConjunctionConstraint(Constraint):
     """
 
     def __init__(
-        self, constraints: List[Constraint], *args, lazy: bool = False, **kwargs
+        self, constraints: list[Constraint], *args, lazy: bool = False, **kwargs
     ):
         """
         Initializes the conjunction constraint with the given constraints.
-        :param List[Constraint] constraints: The constraints to use.
+        :param list[Constraint] constraints: The constraints to use.
         :param args: Additional arguments.
         :param bool lazy: If True, the conjunction is lazy evaluated.
         """
@@ -638,11 +638,11 @@ class DisjunctionConstraint(Constraint):
     """
 
     def __init__(
-        self, constraints: List[Constraint], *args, lazy: bool = False, **kwargs
+        self, constraints: list[Constraint], *args, lazy: bool = False, **kwargs
     ):
         """
         Initializes the disjunction constraint with the given constraints.
-        :param List[Constraint] constraints: The constraints to use.
+        :param list[Constraint] constraints: The constraints to use.
         :param args: Additional arguments.
         :param bool lazy: If True, the disjunction is lazy evaluated.
         """

--- a/src/fandango/constraints/base.py
+++ b/src/fandango/constraints/base.py
@@ -5,7 +5,7 @@ This module contains the base classes for constraints in the fandango library.
 import itertools
 from abc import ABC, abstractmethod
 from copy import copy
-from typing import Dict, Any, Optional
+from typing import Any, Optional
 from tdigest import TDigest
 import math
 
@@ -76,17 +76,17 @@ class Value(GeneticBase):
         """
         super().__init__(*args, **kwargs)
         self.expression = expression
-        self.cache: Dict[int, ValueFitness] = dict()
+        self.cache: dict[int, ValueFitness] = dict()
 
     def fitness(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, DerivationTree]] = None,
+        scope: Optional[dict[NonTerminal, DerivationTree]] = None,
     ) -> ValueFitness:
         """
         Calculate the fitness of the tree based on the given expression.
         :param DerivationTree tree: The tree to evaluate.
-        :param Optional[Dict[NonTerminal, DerivationTree]] scope: The scope of the tree.
+        :param Optional[dict[NonTerminal, DerivationTree]] scope: The scope of the tree.
         :return ValueFitness: The fitness of the tree.
         """
         tree_hash = self.get_hash(tree, scope)
@@ -173,24 +173,24 @@ class Constraint(GeneticBase, ABC):
 
     def __init__(
         self,
-        searches: Optional[Dict[str, NonTerminalSearch]] = None,
-        local_variables: Optional[Dict[str, Any]] = None,
-        global_variables: Optional[Dict[str, Any]] = None,
+        searches: Optional[dict[str, NonTerminalSearch]] = None,
+        local_variables: Optional[dict[str, Any]] = None,
+        global_variables: Optional[dict[str, Any]] = None,
     ):
         """
         Initializes the constraint with the given searches, local variables, and global variables.
-        :param Optional[Dict[str, NonTerminalSearch]] searches: The searches to use.
-        :param Optional[Dict[str, Any]] local_variables: The local variables to use.
-        :param Optional[Dict[str, Any]] global_variables: The global variables to use.
+        :param Optional[dict[str, NonTerminalSearch]] searches: The searches to use.
+        :param Optional[dict[str, Any]] local_variables: The local variables to use.
+        :param Optional[dict[str, Any]] global_variables: The global variables to use.
         """
         super().__init__(searches, local_variables, global_variables)
-        self.cache: Dict[int, ConstraintFitness] = dict()
+        self.cache: dict[int, ConstraintFitness] = dict()
 
     @abstractmethod
     def fitness(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, DerivationTree]] = None,
+        scope: Optional[dict[NonTerminal, DerivationTree]] = None,
     ) -> ConstraintFitness:
         """
         Abstract method to calculate the fitness of the tree.
@@ -253,12 +253,12 @@ class ExpressionConstraint(Constraint):
         self.expression = expression
 
     def fitness(
-        self, tree: DerivationTree, scope: Optional[Dict[str, DerivationTree]] = None
+        self, tree: DerivationTree, scope: Optional[dict[str, DerivationTree]] = None
     ) -> ConstraintFitness:
         """
         Calculate the fitness of the tree based on whether the given expression evaluates to True.
         :param DerivationTree tree: The tree to evaluate.
-        :param Optional[Dict[str, DerivationTree]] scope: The scope of the tree.
+        :param Optional[dict[str, DerivationTree]] scope: The scope of the tree.
         """
         tree_hash = self.get_hash(tree, scope)
         # If the fitness has already been calculated, return the cached value
@@ -360,7 +360,7 @@ class ComparisonConstraint(Constraint):
         self.types_checked = False
 
     def fitness(
-        self, tree: DerivationTree, scope: Optional[Dict[str, DerivationTree]] = None
+        self, tree: DerivationTree, scope: Optional[dict[str, DerivationTree]] = None
     ) -> ConstraintFitness:
         """
         Calculate the fitness of the tree based on the given comparison.
@@ -571,12 +571,12 @@ class ConjunctionConstraint(Constraint):
         self.lazy = lazy
 
     def fitness(
-        self, tree: DerivationTree, scope: Optional[Dict[str, DerivationTree]] = None
+        self, tree: DerivationTree, scope: Optional[dict[str, DerivationTree]] = None
     ) -> ConstraintFitness:
         """
         Calculate the fitness of the tree based on the given conjunction.
         :param DerivationTree tree: The tree to evaluate.
-        :param Optional[Dict[str, DerivationTree]] scope: The scope of the tree.
+        :param Optional[dict[str, DerivationTree]] scope: The scope of the tree.
         :return ConstraintFitness: The fitness of the tree.
         """
         tree_hash = self.get_hash(tree, scope)
@@ -651,12 +651,12 @@ class DisjunctionConstraint(Constraint):
         self.lazy = lazy
 
     def fitness(
-        self, tree: DerivationTree, scope: Optional[Dict[str, DerivationTree]] = None
+        self, tree: DerivationTree, scope: Optional[dict[str, DerivationTree]] = None
     ) -> ConstraintFitness:
         """
         Calculate the fitness of the tree based on the given disjunction.
         :param DerivationTree tree: The tree to evaluate.
-        :param Optional[Dict[str, DerivationTree]] scope: The scope of the tree.
+        :param Optional[dict[str, DerivationTree]] scope: The scope of the tree.
         :return ConstraintFitness: The fitness of the tree.
         """
         tree_hash = self.get_hash(tree, scope)
@@ -728,12 +728,12 @@ class ImplicationConstraint(Constraint):
         self.consequent = consequent
 
     def fitness(
-        self, tree: DerivationTree, scope: Optional[Dict[str, DerivationTree]] = None
+        self, tree: DerivationTree, scope: Optional[dict[str, DerivationTree]] = None
     ) -> ConstraintFitness:
         """
         Calculate the fitness of the tree based on the given implication.
         :param DerivationTree tree: The tree to evaluate.
-        :param Optional[Dict[str, DerivationTree]] scope: The scope of the tree.
+        :param Optional[dict[str, DerivationTree]] scope: The scope of the tree.
         :return ConstraintFitness: The fitness of the tree.
         """
         tree_hash = self.get_hash(tree, scope)
@@ -808,12 +808,12 @@ class ExistsConstraint(Constraint):
     def fitness(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, DerivationTree]] = None,
+        scope: Optional[dict[NonTerminal, DerivationTree]] = None,
     ) -> ConstraintFitness:
         """
         Calculate the fitness of the tree based on the given exists constraint.
         :param DerivationTree tree: The tree to evaluate.
-        :param Optional[Dict[NonTerminal, DerivationTree]] scope: The scope of the tree.
+        :param Optional[dict[NonTerminal, DerivationTree]] scope: The scope of the tree.
         :return ConstraintFitness: The fitness of the tree.
         """
         tree_hash = self.get_hash(tree, scope)
@@ -901,12 +901,12 @@ class ForallConstraint(Constraint):
     def fitness(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, DerivationTree]] = None,
+        scope: Optional[dict[NonTerminal, DerivationTree]] = None,
     ) -> ConstraintFitness:
         """
         Calculate the fitness of the tree based on the given forall constraint.
         :param DerivationTree tree: The tree to evaluate.
-        :param Optional[Dict[NonTerminal, DerivationTree]] scope: The scope of the tree.
+        :param Optional[dict[NonTerminal, DerivationTree]] scope: The scope of the tree.
         :return ConstraintFitness: The fitness of the tree.
         """
         tree_hash = self.get_hash(tree, scope)

--- a/src/fandango/constraints/fitness.py
+++ b/src/fandango/constraints/fitness.py
@@ -244,10 +244,10 @@ class GeneticBase(abc.ABC):
         Get all possible combinations of trees that satisfy the searches.
         :param DerivationTree tree: The tree to calculate the fitness.
         :param Optional[Dict[NonTerminal, DerivationTree]] scope: The scope of non-terminals matching to trees.
-        :return list[List[Tuple[str, DerivationTree]]]: The list of combinations of trees that fill all non-terminals
+        :return list[list[Tuple[str, DerivationTree]]]: The list of combinations of trees that fill all non-terminals
         in the genetic base.
         """
-        nodes: list[List[Tuple[str, DerivationTree]]] = []
+        nodes: list[list[Tuple[str, DerivationTree]]] = []
         for name, search in self.searches.items():
             nodes.append(
                 [(name, container) for container in search.find(tree, scope=scope)]

--- a/src/fandango/constraints/fitness.py
+++ b/src/fandango/constraints/fitness.py
@@ -5,7 +5,7 @@ The `fitness` module provides the `Fitness` class and its subclasses `ValueFitne
 import abc
 import enum
 import itertools
-from typing import Optional, Dict, Any, Tuple
+from typing import Optional, Any
 
 from fandango.language.search import NonTerminalSearch
 from fandango.language.symbol import NonTerminal
@@ -43,14 +43,14 @@ class FailingTree:
         self,
         tree: DerivationTree,
         cause: "GeneticBase",
-        suggestions: Optional[list[Tuple[Comparison, Any, ComparisonSide]]] = None,
+        suggestions: Optional[list[tuple[Comparison, Any, ComparisonSide]]] = None,
     ):
         """
         Initialize the FailingTree with the given tree, cause, and suggestions.
 
         :param DerivationTree tree: The tree that failed to satisfy the constraint.
         :param GeneticBase cause: The cause of the failure.
-        :param Optional[list[Tuple[Comparison, Any, ComparisonSide]]] suggestions: The list of suggestions to
+        :param Optional[list[tuple[Comparison, Any, ComparisonSide]]] suggestions: The list of suggestions to
         which causes the cause to fail.
         """
         self.tree = tree
@@ -191,15 +191,15 @@ class GeneticBase(abc.ABC):
 
     def __init__(
         self,
-        searches: Optional[Dict[str, NonTerminalSearch]] = None,
-        local_variables: Optional[Dict[str, Any]] = None,
-        global_variables: Optional[Dict[str, Any]] = None,
+        searches: Optional[dict[str, NonTerminalSearch]] = None,
+        local_variables: Optional[dict[str, Any]] = None,
+        global_variables: Optional[dict[str, Any]] = None,
     ):
         """
         Initialize the GeneticBase with the given searches, local variables, and global variables.
-        :param Optional[Dict[str, NonTerminalSearch]] searches: The dictionary of searches.
-        :param Optional[Dict[str, Any]] local_variables: The dictionary of local variables.
-        :param Optional[Dict[str, Any]] global_variables: The dictionary of global variables.
+        :param Optional[dict[str, NonTerminalSearch]] searches: The dictionary of searches.
+        :param Optional[dict[str, Any]] local_variables: The dictionary of local variables.
+        :param Optional[dict[str, Any]] global_variables: The dictionary of global variables.
         """
         self.searches = searches or dict()
         self.local_variables = local_variables or dict()
@@ -218,12 +218,12 @@ class GeneticBase(abc.ABC):
     def fitness(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, DerivationTree]] = None,
+        scope: Optional[dict[NonTerminal, DerivationTree]] = None,
     ) -> Fitness:
         """
         Abstract method to calculate the fitness of the tree.
         :param DerivationTree tree: The tree to calculate the fitness.
-        :param Optional[Dict[NonTerminal, DerivationTree]] scope: The scope of non-terminals matching to trees.
+        :param Optional[dict[NonTerminal, DerivationTree]] scope: The scope of non-terminals matching to trees.
         :return Fitness: The fitness of the tree.
         """
         raise NotImplementedError("Fitness function not implemented")
@@ -231,23 +231,23 @@ class GeneticBase(abc.ABC):
     @staticmethod
     def get_hash(
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, DerivationTree]] = None,
+        scope: Optional[dict[NonTerminal, DerivationTree]] = None,
     ):
         return hash((tree, tuple((scope or {}).items())))
 
     def combinations(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, DerivationTree]] = None,
+        scope: Optional[dict[NonTerminal, DerivationTree]] = None,
     ):
         """
         Get all possible combinations of trees that satisfy the searches.
         :param DerivationTree tree: The tree to calculate the fitness.
-        :param Optional[Dict[NonTerminal, DerivationTree]] scope: The scope of non-terminals matching to trees.
-        :return list[list[Tuple[str, DerivationTree]]]: The list of combinations of trees that fill all non-terminals
+        :param Optional[dict[NonTerminal, DerivationTree]] scope: The scope of non-terminals matching to trees.
+        :return list[list[tuple[str, DerivationTree]]]: The list of combinations of trees that fill all non-terminals
         in the genetic base.
         """
-        nodes: list[list[Tuple[str, DerivationTree]]] = []
+        nodes: list[list[tuple[str, DerivationTree]]] = []
         for name, search in self.searches.items():
             nodes.append(
                 [(name, container) for container in search.find(tree, scope=scope)]
@@ -257,12 +257,12 @@ class GeneticBase(abc.ABC):
     def check(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, DerivationTree]] = None,
+        scope: Optional[dict[NonTerminal, DerivationTree]] = None,
     ) -> bool:
         """
         Check if the tree satisfies the genetic base.
         :param DerivationTree tree: The tree to check.
-        :param Optional[Dict[NonTerminal, DerivationTree]] scope: The scope of non-terminals matching to trees.
+        :param Optional[dict[NonTerminal, DerivationTree]] scope: The scope of non-terminals matching to trees.
         :return bool: True if the tree satisfies the genetic base, False otherwise.
         """
         return self.fitness(tree, scope).success

--- a/src/fandango/constraints/fitness.py
+++ b/src/fandango/constraints/fitness.py
@@ -5,7 +5,7 @@ The `fitness` module provides the `Fitness` class and its subclasses `ValueFitne
 import abc
 import enum
 import itertools
-from typing import List, Optional, Dict, Any, Tuple
+from typing import Optional, Dict, Any, Tuple
 
 from fandango.language.search import NonTerminalSearch
 from fandango.language.symbol import NonTerminal
@@ -43,14 +43,14 @@ class FailingTree:
         self,
         tree: DerivationTree,
         cause: "GeneticBase",
-        suggestions: Optional[List[Tuple[Comparison, Any, ComparisonSide]]] = None,
+        suggestions: Optional[list[Tuple[Comparison, Any, ComparisonSide]]] = None,
     ):
         """
         Initialize the FailingTree with the given tree, cause, and suggestions.
 
         :param DerivationTree tree: The tree that failed to satisfy the constraint.
         :param GeneticBase cause: The cause of the failure.
-        :param Optional[List[Tuple[Comparison, Any, ComparisonSide]]] suggestions: The list of suggestions to
+        :param Optional[list[Tuple[Comparison, Any, ComparisonSide]]] suggestions: The list of suggestions to
         which causes the cause to fail.
         """
         self.tree = tree
@@ -75,12 +75,14 @@ class Fitness(abc.ABC):
     Abstract class to represent the fitness of a tree.
     """
 
-    def __init__(self, success: bool, failing_trees: List[FailingTree] = None):
+    def __init__(
+        self, success: bool, failing_trees: Optional[list[FailingTree]] = None
+    ):
         """
         Initialize the Fitness with the given success and failing trees.
 
         :param bool success: The success of the fitness.
-        :param Optional[List[FailingTree]] failing_trees: The list of failing trees.
+        :param Optional[list[FailingTree]] failing_trees: The list of failing trees.
         """
         self.success = success
         self.failing_trees = failing_trees or []
@@ -107,12 +109,14 @@ class ValueFitness(Fitness):
     """
 
     def __init__(
-        self, values: List[float] = None, failing_trees: List[FailingTree] = None
+        self,
+        values: Optional[list[float]] = None,
+        failing_trees: Optional[list[FailingTree]] = None,
     ):
         """
         Initialize the ValueFitness with the given values and failing trees.
-        :param Optional[List[float]] values: The list of values.
-        :param Optional[List[FailingTree]] failing_trees: The list of failing trees.
+        :param Optional[list[float]] values: The list of values.
+        :param Optional[list[FailingTree]] failing_trees: The list of failing trees.
         """
         super().__init__(True, failing_trees)
         self.values = values or []
@@ -147,14 +151,14 @@ class ConstraintFitness(Fitness):
         solved: int,
         total: int,
         success: bool,
-        failing_trees: List[FailingTree] = None,
+        failing_trees: Optional[list[FailingTree]] = None,
     ):
         """
         Initialize the ConstraintFitness with the given solved, total, success, and failing trees.
         :param int solved: The number of constraints solved by the tree.
         :param int total: The total number of constraints.
         :param bool success: The success of the fitness.
-        :param Optional[List[FailingTree]] failing_trees: The list of failing trees.
+        :param Optional[list[FailingTree]] failing_trees: The list of failing trees.
         """
         super().__init__(success, failing_trees)
         self.solved = solved
@@ -204,7 +208,7 @@ class GeneticBase(abc.ABC):
     def get_access_points(self):
         """
         Get the access points of the genetic base, i.e., the non-terminal that are considered in this genetic base.
-        :return List[NonTerminal]: The list of access points.
+        :return list[NonTerminal]: The list of access points.
         """
         return sum(
             [search.get_access_points() for search in self.searches.values()], []
@@ -240,10 +244,10 @@ class GeneticBase(abc.ABC):
         Get all possible combinations of trees that satisfy the searches.
         :param DerivationTree tree: The tree to calculate the fitness.
         :param Optional[Dict[NonTerminal, DerivationTree]] scope: The scope of non-terminals matching to trees.
-        :return List[List[Tuple[str, DerivationTree]]]: The list of combinations of trees that fill all non-terminals
+        :return list[List[Tuple[str, DerivationTree]]]: The list of combinations of trees that fill all non-terminals
         in the genetic base.
         """
-        nodes: List[List[Tuple[str, DerivationTree]]] = []
+        nodes: list[List[Tuple[str, DerivationTree]]] = []
         for name, search in self.searches.items():
             nodes.append(
                 [(name, container) for container in search.find(tree, scope=scope)]
@@ -267,7 +271,7 @@ class GeneticBase(abc.ABC):
         """
         Get the failing nodes of the tree.
         :param DerivationTree tree: The tree to check.
-        :return List[FailingTree]: The list of failing trees
+        :return list[FailingTree]: The list of failing trees
         """
         return self.fitness(tree).failing_trees
 

--- a/src/fandango/evolution/adaptation.py
+++ b/src/fandango/evolution/adaptation.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import Tuple
 
 from fandango.evolution.evaluation import Evaluator
 from fandango.language.grammar import DerivationTree
@@ -31,7 +31,7 @@ class AdaptiveTuner:
         generation: int,
         prev_best_fitness: float,
         current_best_fitness: float,
-        population: List[DerivationTree],
+        population: list[DerivationTree],
         evaluator: Evaluator,
         current_max_repetition: int,
     ) -> Tuple[float, float]:
@@ -108,8 +108,8 @@ class AdaptiveTuner:
     def log_generation_statistics(
         self,
         generation: int,
-        evaluation: List[Tuple[DerivationTree, float, List]],
-        population: List[DerivationTree],
+        evaluation: list[Tuple[DerivationTree, float, list]],
+        population: list[DerivationTree],
         evaluator: Evaluator,
     ):
         best_fitness = max(fitness for _, fitness, _ in evaluation)

--- a/src/fandango/evolution/adaptation.py
+++ b/src/fandango/evolution/adaptation.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from fandango.evolution.evaluation import Evaluator
 from fandango.language.grammar import DerivationTree
 from fandango.logger import LOGGER
@@ -34,7 +32,7 @@ class AdaptiveTuner:
         population: list[DerivationTree],
         evaluator: Evaluator,
         current_max_repetition: int,
-    ) -> Tuple[float, float]:
+    ) -> tuple[float, float]:
         diversity_map = evaluator.compute_diversity_bonus(population)
         avg_diversity = (
             sum(diversity_map.values()) / len(diversity_map) if diversity_map else 0
@@ -108,7 +106,7 @@ class AdaptiveTuner:
     def log_generation_statistics(
         self,
         generation: int,
-        evaluation: list[Tuple[DerivationTree, float, list]],
+        evaluation: list[tuple[DerivationTree, float, list]],
         population: list[DerivationTree],
         evaluator: Evaluator,
     ):

--- a/src/fandango/evolution/algorithm.py
+++ b/src/fandango/evolution/algorithm.py
@@ -107,8 +107,7 @@ class Fandango:
             max_nodes_rate,
         )
 
-        if profiling:
-            self.profiler = Profiler()
+        self.profiler = Profiler() if profiling else None
 
         self.crossover_operator = crossover_method
         self.mutation_method = mutation_method
@@ -120,14 +119,14 @@ class Fandango:
         )
         st_time = time.time()
 
-        if self.profiler:
+        if self.profiler is not None:
             self.profiler.start_timer("initial_population")
 
         self.population = self.population_manager.generate_random_population(
             eval_individual=self.evaluator.evaluate_individual,
             initial_population=initial_population,
         )
-        if self.profiler:
+        if self.profiler is not None:
             self.profiler.stop_timer("initial_population")
             self.profiler.increment("initial_population", len(self.population))
 
@@ -136,10 +135,10 @@ class Fandango:
         )
 
         # Evaluate initial population
-        if self.profiler:
+        if self.profiler is not None:
             self.profiler.start_timer("evaluate_population")
         self.evaluation = self.evaluator.evaluate_population(self.population)
-        if self.profiler:
+        if self.profiler is not None:
             self.profiler.stop_timer("evaluate_population")
             self.profiler.increment("evaluate_population", len(self.population))
         self.fitness = (
@@ -221,12 +220,12 @@ class Fandango:
 
         :return: A tuple containing the new population and the set of unique hashes of the individuals in the new population.
         """
-        if self.profiler:
+        if self.profiler is not None:
             self.profiler.start_timer("select_elites")
         new_population = self.evaluator.select_elites(
             self.evaluation, self.elitism_rate, self.population_size
         )
-        if self.profiler:
+        if self.profiler is not None:
             self.profiler.stop_timer("select_elites")
             self.profiler.increment("select_elites", len(new_population))
 
@@ -243,21 +242,21 @@ class Fandango:
         :param unique_hashes: The set of unique hashes of the individuals in the new population.
         """
         try:
-            if self.profiler:
+            if self.profiler is not None:
                 self.profiler.start_timer("tournament_selection")
             parent1, parent2 = self.evaluator.tournament_selection(
                 self.evaluation, self.tournament_size
             )
-            if self.profiler:
+            if self.profiler is not None:
                 self.profiler.stop_timer("tournament_selection")
                 self.profiler.increment("tournament_selection", 2)
 
-            if self.profiler:
+            if self.profiler is not None:
                 self.profiler.start_timer("crossover")
             child1, child2 = self.crossover_operator.crossover(
                 self.grammar, parent1, parent2
             )
-            if self.profiler:
+            if self.profiler is not None:
                 self.profiler.stop_timer("crossover")
                 self.profiler.increment("crossover", 2)
 
@@ -266,7 +265,7 @@ class Fandango:
             )
             self.evaluator.evaluate_individual(child1)
 
-            if self.profiler:
+            if self.profiler is not None:
                 self.profiler.start_timer("filling")
                 count = len(new_population)
             if len(new_population) < self.population_size:
@@ -275,7 +274,7 @@ class Fandango:
                 )
                 self.evaluator.evaluate_individual(child2)
 
-            if self.profiler:
+            if self.profiler is not None:
                 self.profiler.stop_timer("filling")
                 self.profiler.increment("filling", len(new_population) - count)
             self.crossovers_made += 2
@@ -299,7 +298,7 @@ class Fandango:
         for individual in mutation_pool:
             if random.random() < self.adaptive_tuner.mutation_rate:
                 try:
-                    if self.profiler:
+                    if self.profiler is not None:
                         self.profiler.start_timer("mutation")
 
                     mutated_individual = self.mutation_method.mutate(
@@ -308,7 +307,7 @@ class Fandango:
                         self.evaluator.evaluate_individual,
                         self.current_max_nodes,
                     )
-                    if self.profiler:
+                    if self.profiler is not None:
                         self.profiler.stop_timer("mutation")
                         self.profiler.increment("mutation", 1)
                     mutated_population.append(mutated_individual)
@@ -387,14 +386,14 @@ class Fandango:
                 # Hence, we periodically flush the fitness cache to re-evaluate the population.
                 self.evaluator.fitness_cache = {}
 
-            if self.profiler:
+            if self.profiler is not None:
                 self.profiler.start_timer("evaluate_population")
             self.evaluation = self.evaluator.evaluate_population(self.population)
             # Keep only the fittest individuals
             self.evaluation = sorted(self.evaluation, key=lambda x: x[1], reverse=True)[
                 : self.population_size
             ]
-            if self.profiler:
+            if self.profiler is not None:
                 self.profiler.stop_timer("evaluate_population")
                 self.profiler.increment("evaluate_population", len(self.population))
             self.fitness = (
@@ -439,7 +438,7 @@ class Fandango:
         LOGGER.debug(f"Crossovers made: {self.crossovers_made}")
         LOGGER.debug(f"Mutations made: {self.mutations_made}")
 
-        if self.profiler:
+        if self.profiler is not None:
             self.profiler.log_results()
 
         if self.fitness < self.expected_fitness:

--- a/src/fandango/evolution/algorithm.py
+++ b/src/fandango/evolution/algorithm.py
@@ -107,8 +107,7 @@ class Fandango:
             max_nodes_rate,
         )
 
-        self.profiling = profiling
-        if self.profiling:
+        if profiling:
             self.profiler = Profiler()
 
         self.crossover_operator = crossover_method
@@ -121,14 +120,14 @@ class Fandango:
         )
         st_time = time.time()
 
-        if self.profiling:
+        if self.profiler:
             self.profiler.start_timer("initial_population")
 
         self.population = self.population_manager.generate_random_population(
             eval_individual=self.evaluator.evaluate_individual,
             initial_population=initial_population,
         )
-        if self.profiling:
+        if self.profiler:
             self.profiler.stop_timer("initial_population")
             self.profiler.increment("initial_population", len(self.population))
 
@@ -137,10 +136,10 @@ class Fandango:
         )
 
         # Evaluate initial population
-        if self.profiling:
+        if self.profiler:
             self.profiler.start_timer("evaluate_population")
         self.evaluation = self.evaluator.evaluate_population(self.population)
-        if self.profiling:
+        if self.profiler:
             self.profiler.stop_timer("evaluate_population")
             self.profiler.increment("evaluate_population", len(self.population))
         self.fitness = (
@@ -222,12 +221,12 @@ class Fandango:
 
         :return: A tuple containing the new population and the set of unique hashes of the individuals in the new population.
         """
-        if self.profiling:
+        if self.profiler:
             self.profiler.start_timer("select_elites")
         new_population = self.evaluator.select_elites(
             self.evaluation, self.elitism_rate, self.population_size
         )
-        if self.profiling:
+        if self.profiler:
             self.profiler.stop_timer("select_elites")
             self.profiler.increment("select_elites", len(new_population))
 
@@ -244,21 +243,21 @@ class Fandango:
         :param unique_hashes: The set of unique hashes of the individuals in the new population.
         """
         try:
-            if self.profiling:
+            if self.profiler:
                 self.profiler.start_timer("tournament_selection")
             parent1, parent2 = self.evaluator.tournament_selection(
                 self.evaluation, self.tournament_size
             )
-            if self.profiling:
+            if self.profiler:
                 self.profiler.stop_timer("tournament_selection")
                 self.profiler.increment("tournament_selection", 2)
 
-            if self.profiling:
+            if self.profiler:
                 self.profiler.start_timer("crossover")
             child1, child2 = self.crossover_operator.crossover(
                 self.grammar, parent1, parent2
             )
-            if self.profiling:
+            if self.profiler:
                 self.profiler.stop_timer("crossover")
                 self.profiler.increment("crossover", 2)
 
@@ -267,7 +266,7 @@ class Fandango:
             )
             self.evaluator.evaluate_individual(child1)
 
-            if self.profiling:
+            if self.profiler:
                 self.profiler.start_timer("filling")
                 count = len(new_population)
             if len(new_population) < self.population_size:
@@ -276,7 +275,7 @@ class Fandango:
                 )
                 self.evaluator.evaluate_individual(child2)
 
-            if self.profiling:
+            if self.profiler:
                 self.profiler.stop_timer("filling")
                 self.profiler.increment("filling", len(new_population) - count)
             self.crossovers_made += 2
@@ -300,7 +299,7 @@ class Fandango:
         for individual in mutation_pool:
             if random.random() < self.adaptive_tuner.mutation_rate:
                 try:
-                    if self.profiling:
+                    if self.profiler:
                         self.profiler.start_timer("mutation")
 
                     mutated_individual = self.mutation_method.mutate(
@@ -309,7 +308,7 @@ class Fandango:
                         self.evaluator.evaluate_individual,
                         self.current_max_nodes,
                     )
-                    if self.profiling:
+                    if self.profiler:
                         self.profiler.stop_timer("mutation")
                         self.profiler.increment("mutation", 1)
                     mutated_population.append(mutated_individual)
@@ -388,14 +387,14 @@ class Fandango:
                 # Hence, we periodically flush the fitness cache to re-evaluate the population.
                 self.evaluator.fitness_cache = {}
 
-            if self.profiling:
+            if self.profiler:
                 self.profiler.start_timer("evaluate_population")
             self.evaluation = self.evaluator.evaluate_population(self.population)
             # Keep only the fittest individuals
             self.evaluation = sorted(self.evaluation, key=lambda x: x[1], reverse=True)[
                 : self.population_size
             ]
-            if self.profiling:
+            if self.profiler:
                 self.profiler.stop_timer("evaluate_population")
                 self.profiler.increment("evaluate_population", len(self.population))
             self.fitness = (
@@ -440,7 +439,7 @@ class Fandango:
         LOGGER.debug(f"Crossovers made: {self.crossovers_made}")
         LOGGER.debug(f"Mutations made: {self.mutations_made}")
 
-        if self.profiling:
+        if self.profiler:
             self.profiler.log_results()
 
         if self.fitness < self.expected_fitness:

--- a/src/fandango/evolution/algorithm.py
+++ b/src/fandango/evolution/algorithm.py
@@ -107,7 +107,7 @@ class Fandango:
             max_nodes_rate,
         )
 
-        self.profiler = Profiler() if profiling else None
+        self.profiler = Profiler(enabled=profiling)
 
         self.crossover_operator = crossover_method
         self.mutation_method = mutation_method
@@ -119,28 +119,23 @@ class Fandango:
         )
         st_time = time.time()
 
-        if self.profiler is not None:
-            self.profiler.start_timer("initial_population")
-
+        self.profiler.start_timer("initial_population")
         self.population = self.population_manager.generate_random_population(
             eval_individual=self.evaluator.evaluate_individual,
             initial_population=initial_population,
         )
-        if self.profiler is not None:
-            self.profiler.stop_timer("initial_population")
-            self.profiler.increment("initial_population", len(self.population))
+        self.profiler.stop_timer("initial_population")
+        self.profiler.increment("initial_population", len(self.population))
 
         LOGGER.info(
             f"Initial population generated in {time.time() - st_time:.2f} seconds"
         )
 
         # Evaluate initial population
-        if self.profiler is not None:
-            self.profiler.start_timer("evaluate_population")
+        self.profiler.start_timer("evaluate_population")
         self.evaluation = self.evaluator.evaluate_population(self.population)
-        if self.profiler is not None:
-            self.profiler.stop_timer("evaluate_population")
-            self.profiler.increment("evaluate_population", len(self.population))
+        self.profiler.stop_timer("evaluate_population")
+        self.profiler.increment("evaluate_population", len(self.population))
         self.fitness = (
             sum(fitness for _, fitness, _ in self.evaluation) / self.population_size
         )
@@ -220,14 +215,12 @@ class Fandango:
 
         :return: A tuple containing the new population and the set of unique hashes of the individuals in the new population.
         """
-        if self.profiler is not None:
-            self.profiler.start_timer("select_elites")
+        self.profiler.start_timer("select_elites")
         new_population = self.evaluator.select_elites(
             self.evaluation, self.elitism_rate, self.population_size
         )
-        if self.profiler is not None:
-            self.profiler.stop_timer("select_elites")
-            self.profiler.increment("select_elites", len(new_population))
+        self.profiler.stop_timer("select_elites")
+        self.profiler.increment("select_elites", len(new_population))
 
         unique_hashes = {hash(ind) for ind in new_population}
         return new_population, unique_hashes
@@ -242,41 +235,35 @@ class Fandango:
         :param unique_hashes: The set of unique hashes of the individuals in the new population.
         """
         try:
-            if self.profiler is not None:
-                self.profiler.start_timer("tournament_selection")
+            self.profiler.start_timer("tournament_selection")
             parent1, parent2 = self.evaluator.tournament_selection(
                 self.evaluation, self.tournament_size
             )
-            if self.profiler is not None:
-                self.profiler.stop_timer("tournament_selection")
-                self.profiler.increment("tournament_selection", 2)
+            self.profiler.stop_timer("tournament_selection")
+            self.profiler.increment("tournament_selection", 2)
 
-            if self.profiler is not None:
-                self.profiler.start_timer("crossover")
+            self.profiler.start_timer("crossover")
             child1, child2 = self.crossover_operator.crossover(
                 self.grammar, parent1, parent2
             )
-            if self.profiler is not None:
-                self.profiler.stop_timer("crossover")
-                self.profiler.increment("crossover", 2)
+            self.profiler.stop_timer("crossover")
+            self.profiler.increment("crossover", 2)
 
             PopulationManager.add_unique_individual(
                 new_population, child1, unique_hashes
             )
             self.evaluator.evaluate_individual(child1)
 
-            if self.profiler is not None:
-                self.profiler.start_timer("filling")
-                count = len(new_population)
+            self.profiler.start_timer("filling")
+            count = len(new_population)
             if len(new_population) < self.population_size:
                 PopulationManager.add_unique_individual(
                     new_population, child2, unique_hashes
                 )
                 self.evaluator.evaluate_individual(child2)
 
-            if self.profiler is not None:
-                self.profiler.stop_timer("filling")
-                self.profiler.increment("filling", len(new_population) - count)
+            self.profiler.stop_timer("filling")
+            self.profiler.increment("filling", len(new_population) - count)
             self.crossovers_made += 2
         except Exception as e:
             LOGGER.error(f"Error during crossover: {e}")
@@ -298,18 +285,15 @@ class Fandango:
         for individual in mutation_pool:
             if random.random() < self.adaptive_tuner.mutation_rate:
                 try:
-                    if self.profiler is not None:
-                        self.profiler.start_timer("mutation")
-
+                    self.profiler.start_timer("mutation")
                     mutated_individual = self.mutation_method.mutate(
                         individual,
                         self.grammar,
                         self.evaluator.evaluate_individual,
                         self.current_max_nodes,
                     )
-                    if self.profiler is not None:
-                        self.profiler.stop_timer("mutation")
-                        self.profiler.increment("mutation", 1)
+                    self.profiler.stop_timer("mutation")
+                    self.profiler.increment("mutation", 1)
                     mutated_population.append(mutated_individual)
                     self.mutations_made += 1
                 except Exception as e:
@@ -386,16 +370,14 @@ class Fandango:
                 # Hence, we periodically flush the fitness cache to re-evaluate the population.
                 self.evaluator.fitness_cache = {}
 
-            if self.profiler is not None:
-                self.profiler.start_timer("evaluate_population")
+            self.profiler.start_timer("evaluate_population")
             self.evaluation = self.evaluator.evaluate_population(self.population)
             # Keep only the fittest individuals
             self.evaluation = sorted(self.evaluation, key=lambda x: x[1], reverse=True)[
                 : self.population_size
             ]
-            if self.profiler is not None:
-                self.profiler.stop_timer("evaluate_population")
-                self.profiler.increment("evaluate_population", len(self.population))
+            self.profiler.stop_timer("evaluate_population")
+            self.profiler.increment("evaluate_population", len(self.population))
             self.fitness = (
                 sum(fitness for _, fitness, _ in self.evaluation) / self.population_size
             )
@@ -438,8 +420,7 @@ class Fandango:
         LOGGER.debug(f"Crossovers made: {self.crossovers_made}")
         LOGGER.debug(f"Mutations made: {self.mutations_made}")
 
-        if self.profiler is not None:
-            self.profiler.log_results()
+        self.profiler.log_results()
 
         if self.fitness < self.expected_fitness:
             LOGGER.error("Population did not converge to a perfect population")

--- a/src/fandango/evolution/algorithm.py
+++ b/src/fandango/evolution/algorithm.py
@@ -3,7 +3,7 @@ import enum
 import logging
 import random
 import time
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 from fandango import FandangoFailedError, FandangoParseError, FandangoValueError
 from fandango.constraints.base import Constraint, SoftValue

--- a/src/fandango/evolution/algorithm.py
+++ b/src/fandango/evolution/algorithm.py
@@ -3,7 +3,7 @@ import enum
 import logging
 import random
 import time
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 
 from fandango import FandangoFailedError, FandangoParseError, FandangoValueError
 from fandango.constraints.base import Constraint, SoftValue
@@ -31,10 +31,10 @@ class Fandango:
     def __init__(
         self,
         grammar: Grammar,
-        constraints: List[Constraint],
+        constraints: list[Constraint],
         population_size: int = 100,
         desired_solutions: int = 0,
-        initial_population: Optional[List[Union[DerivationTree, str]]] = None,
+        initial_population: Optional[list[Union[DerivationTree, str]]] = None,
         max_generations: int = 500,
         expected_fitness: float = 1.0,
         elitism_rate: float = 0.1,
@@ -157,8 +157,8 @@ class Fandango:
         self.desired_solutions = desired_solutions
 
     def _parse_and_deduplicate(
-        self, population: Optional[List[Union[DerivationTree, str]]]
-    ) -> List[DerivationTree]:
+        self, population: Optional[list[Union[DerivationTree, str]]]
+    ) -> list[DerivationTree]:
         """
         Parses and deduplicates the initial population along unique parse trees. If no initial population is provided, an empty list is returned.
 
@@ -188,7 +188,7 @@ class Fandango:
             )
         return unique_population
 
-    def evolve(self) -> List[DerivationTree]:
+    def evolve(self) -> list[DerivationTree]:
         LOGGER.info("---------- Starting evolution ----------")
         start_time = time.time()
         prev_best_fitness = 0.0
@@ -420,7 +420,7 @@ class Fandango:
 
         return self.solution
 
-    def select_elites(self) -> List[DerivationTree]:
+    def select_elites(self) -> list[DerivationTree]:
         return [
             x[0]
             for x in sorted(self.evaluation, key=lambda x: x[1], reverse=True)[

--- a/src/fandango/evolution/crossover.py
+++ b/src/fandango/evolution/crossover.py
@@ -1,7 +1,7 @@
 import copy
 import random
 from abc import ABC, abstractmethod
-from typing import Tuple
+
 
 from fandango.language.grammar import Grammar
 from fandango.language.tree import DerivationTree
@@ -11,14 +11,14 @@ class CrossoverOperator(ABC):
     @abstractmethod
     def crossover(
         self, grammar: Grammar, parent1: DerivationTree, parent2: DerivationTree
-    ) -> Tuple[DerivationTree, DerivationTree]:
+    ) -> tuple[DerivationTree, DerivationTree]:
         pass
 
 
 class SimpleSubtreeCrossover(CrossoverOperator):
     def crossover(
         self, grammar: Grammar, parent1: DerivationTree, parent2: DerivationTree
-    ) -> Tuple[DerivationTree, DerivationTree]:
+    ) -> tuple[DerivationTree, DerivationTree]:
         symbols1 = parent1.get_non_terminal_symbols()
         symbols2 = parent2.get_non_terminal_symbols()
         common_symbols = symbols1.intersection(symbols2)

--- a/src/fandango/evolution/evaluation.py
+++ b/src/fandango/evolution/evaluation.py
@@ -1,6 +1,6 @@
 import concurrent.futures
 import random
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Tuple, Union
 
 from fandango.constraints.base import Constraint, SoftValue
 from fandango.constraints.fitness import FailingTree
@@ -12,7 +12,7 @@ class Evaluator:
     def __init__(
         self,
         grammar: Grammar,
-        constraints: List[Union[Constraint, SoftValue]],
+        constraints: list[Union[Constraint, SoftValue]],
         expected_fitness: float,
         diversity_k: int,
         diversity_weight: float,
@@ -20,13 +20,13 @@ class Evaluator:
     ):
         self.grammar = grammar
         self.constraints = constraints
-        self.soft_constraints: List[SoftValue] = []
-        self.hard_constraints: List[Constraint] = []
+        self.soft_constraints: list[SoftValue] = []
+        self.hard_constraints: list[Constraint] = []
         self.expected_fitness = expected_fitness
         self.diversity_k = diversity_k
         self.diversity_weight = diversity_weight
         self.warnings_are_errors = warnings_are_errors
-        self.fitness_cache: Dict[int, Tuple[float, List[FailingTree]]] = {}
+        self.fitness_cache: Dict[int, Tuple[float, list[FailingTree]]] = {}
         self.solution = []
         self.solution_set = set()
         self.checks_made = 0
@@ -38,7 +38,7 @@ class Evaluator:
                 self.hard_constraints.append(constraint)
 
     def compute_diversity_bonus(
-        self, individuals: List[DerivationTree]
+        self, individuals: list[DerivationTree]
     ) -> Dict[int, float]:
         k = self.diversity_k
         ind_kpaths: Dict[int, set] = {}
@@ -63,9 +63,9 @@ class Evaluator:
 
     def evaluate_hard_constraints(
         self, individual: DerivationTree
-    ) -> Tuple[float, List[FailingTree]]:
+    ) -> Tuple[float, list[FailingTree]]:
         hard_fitness = 0.0
-        failing_trees: List[FailingTree] = []
+        failing_trees: list[FailingTree] = []
         for constraint in self.hard_constraints:
             try:
                 result = constraint.fitness(individual)
@@ -87,9 +87,9 @@ class Evaluator:
 
     def evaluate_soft_constraints(
         self, individual: DerivationTree
-    ) -> Tuple[float, List[FailingTree]]:
+    ) -> Tuple[float, list[FailingTree]]:
         soft_fitness = 0.0
-        failing_trees: List[FailingTree] = []
+        failing_trees: list[FailingTree] = []
         for constraint in self.soft_constraints:
             try:
                 result = constraint.fitness(individual)
@@ -114,7 +114,7 @@ class Evaluator:
 
     def evaluate_individual(
         self, individual: DerivationTree
-    ) -> Tuple[float, List[FailingTree]]:
+    ) -> Tuple[float, list[FailingTree]]:
         key = hash(individual)
         if key in self.fitness_cache:
             if (
@@ -156,8 +156,8 @@ class Evaluator:
         return fitness, failing_trees
 
     def evaluate_population(
-        self, population: List[DerivationTree]
-    ) -> List[Tuple[DerivationTree, float, List[FailingTree]]]:
+        self, population: list[DerivationTree]
+    ) -> list[Tuple[DerivationTree, float, list[FailingTree]]]:
         evaluation = []
         for individual in population:
             fitness, failing_trees = self.evaluate_individual(individual)
@@ -172,8 +172,8 @@ class Evaluator:
         return evaluation
 
     def evaluate_population_parallel(
-        self, population: List[DerivationTree], num_workers: int = 4
-    ) -> List[Tuple[DerivationTree, float, List]]:
+        self, population: list[DerivationTree], num_workers: int = 4
+    ) -> list[Tuple[DerivationTree, float, list]]:
         evaluation = []
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
             future_to_individual = {
@@ -193,10 +193,10 @@ class Evaluator:
 
     def select_elites(
         self,
-        evaluation: List[Tuple[DerivationTree, float, List]],
+        evaluation: list[Tuple[DerivationTree, float, list]],
         elitism_rate: float,
         population_size: int,
-    ) -> List[DerivationTree]:
+    ) -> list[DerivationTree]:
         return [
             x[0]
             for x in sorted(evaluation, key=lambda x: x[1], reverse=True)[
@@ -205,7 +205,7 @@ class Evaluator:
         ]
 
     def tournament_selection(
-        self, evaluation: List[Tuple[DerivationTree, float, List]], tournament_size: int
+        self, evaluation: list[Tuple[DerivationTree, float, list]], tournament_size: int
     ) -> Tuple[DerivationTree, DerivationTree]:
         tournament = random.sample(evaluation, k=tournament_size)
         tournament.sort(key=lambda x: x[1], reverse=True)

--- a/src/fandango/evolution/evaluation.py
+++ b/src/fandango/evolution/evaluation.py
@@ -1,6 +1,6 @@
 import concurrent.futures
 import random
-from typing import Dict, Tuple, Union
+from typing import Union
 
 from fandango.constraints.base import Constraint, SoftValue
 from fandango.constraints.fitness import FailingTree
@@ -26,7 +26,7 @@ class Evaluator:
         self.diversity_k = diversity_k
         self.diversity_weight = diversity_weight
         self.warnings_are_errors = warnings_are_errors
-        self.fitness_cache: Dict[int, Tuple[float, list[FailingTree]]] = {}
+        self.fitness_cache: dict[int, tuple[float, list[FailingTree]]] = {}
         self.solution = []
         self.solution_set = set()
         self.checks_made = 0
@@ -39,20 +39,20 @@ class Evaluator:
 
     def compute_diversity_bonus(
         self, individuals: list[DerivationTree]
-    ) -> Dict[int, float]:
+    ) -> dict[int, float]:
         k = self.diversity_k
-        ind_kpaths: Dict[int, set] = {}
+        ind_kpaths: dict[int, set] = {}
         for idx, tree in enumerate(individuals):
             # Assuming your grammar is available in evaluator
             paths = self.grammar._extract_k_paths_from_tree(tree, k)
             ind_kpaths[idx] = paths
 
-        frequency: Dict[tuple, int] = {}
+        frequency: dict[tuple, int] = {}
         for paths in ind_kpaths.values():
             for path in paths:
                 frequency[path] = frequency.get(path, 0) + 1
 
-        bonus: Dict[int, float] = {}
+        bonus: dict[int, float] = {}
         for idx, paths in ind_kpaths.items():
             if paths:
                 bonus_score = sum(1.0 / frequency[path] for path in paths) / len(paths)
@@ -63,7 +63,7 @@ class Evaluator:
 
     def evaluate_hard_constraints(
         self, individual: DerivationTree
-    ) -> Tuple[float, list[FailingTree]]:
+    ) -> tuple[float, list[FailingTree]]:
         hard_fitness = 0.0
         failing_trees: list[FailingTree] = []
         for constraint in self.hard_constraints:
@@ -87,7 +87,7 @@ class Evaluator:
 
     def evaluate_soft_constraints(
         self, individual: DerivationTree
-    ) -> Tuple[float, list[FailingTree]]:
+    ) -> tuple[float, list[FailingTree]]:
         soft_fitness = 0.0
         failing_trees: list[FailingTree] = []
         for constraint in self.soft_constraints:
@@ -114,7 +114,7 @@ class Evaluator:
 
     def evaluate_individual(
         self, individual: DerivationTree
-    ) -> Tuple[float, list[FailingTree]]:
+    ) -> tuple[float, list[FailingTree]]:
         key = hash(individual)
         if key in self.fitness_cache:
             if (
@@ -157,7 +157,7 @@ class Evaluator:
 
     def evaluate_population(
         self, population: list[DerivationTree]
-    ) -> list[Tuple[DerivationTree, float, list[FailingTree]]]:
+    ) -> list[tuple[DerivationTree, float, list[FailingTree]]]:
         evaluation = []
         for individual in population:
             fitness, failing_trees = self.evaluate_individual(individual)
@@ -173,7 +173,7 @@ class Evaluator:
 
     def evaluate_population_parallel(
         self, population: list[DerivationTree], num_workers: int = 4
-    ) -> list[Tuple[DerivationTree, float, list]]:
+    ) -> list[tuple[DerivationTree, float, list]]:
         evaluation = []
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
             future_to_individual = {
@@ -193,7 +193,7 @@ class Evaluator:
 
     def select_elites(
         self,
-        evaluation: list[Tuple[DerivationTree, float, list]],
+        evaluation: list[tuple[DerivationTree, float, list]],
         elitism_rate: float,
         population_size: int,
     ) -> list[DerivationTree]:
@@ -205,8 +205,8 @@ class Evaluator:
         ]
 
     def tournament_selection(
-        self, evaluation: list[Tuple[DerivationTree, float, list]], tournament_size: int
-    ) -> Tuple[DerivationTree, DerivationTree]:
+        self, evaluation: list[tuple[DerivationTree, float, list]], tournament_size: int
+    ) -> tuple[DerivationTree, DerivationTree]:
         tournament = random.sample(evaluation, k=tournament_size)
         tournament.sort(key=lambda x: x[1], reverse=True)
         parent1 = tournament[0][0]

--- a/src/fandango/evolution/mutation.py
+++ b/src/fandango/evolution/mutation.py
@@ -1,7 +1,7 @@
 # mutation.py
 import random
 from abc import ABC, abstractmethod
-from typing import Callable, List, Tuple
+from typing import Callable, Tuple
 
 from fandango.constraints.fitness import FailingTree
 from fandango.language.grammar import DerivationTree, Grammar
@@ -13,7 +13,7 @@ class MutationOperator(ABC):
         self,
         individual: DerivationTree,
         grammar: Grammar,
-        evaluate_func: Callable[[DerivationTree], Tuple[float, List[FailingTree]]],
+        evaluate_func: Callable[[DerivationTree], Tuple[float, list[FailingTree]]],
     ) -> DerivationTree:
         """
         Abstract method to perform mutation on an individual.
@@ -31,7 +31,7 @@ class SimpleMutation(MutationOperator):
         self,
         individual: DerivationTree,
         grammar: Grammar,
-        evaluate_func: Callable[[DerivationTree], Tuple[float, List[FailingTree]]],
+        evaluate_func: Callable[[DerivationTree], Tuple[float, list[FailingTree]]],
         max_nodes: int = 50,
     ) -> DerivationTree:
         """

--- a/src/fandango/evolution/mutation.py
+++ b/src/fandango/evolution/mutation.py
@@ -1,7 +1,7 @@
 # mutation.py
 import random
 from abc import ABC, abstractmethod
-from typing import Callable, Tuple
+from typing import Callable
 
 from fandango.constraints.fitness import FailingTree
 from fandango.language.grammar import DerivationTree, Grammar
@@ -13,7 +13,7 @@ class MutationOperator(ABC):
         self,
         individual: DerivationTree,
         grammar: Grammar,
-        evaluate_func: Callable[[DerivationTree], Tuple[float, list[FailingTree]]],
+        evaluate_func: Callable[[DerivationTree], tuple[float, list[FailingTree]]],
     ) -> DerivationTree:
         """
         Abstract method to perform mutation on an individual.
@@ -31,7 +31,7 @@ class SimpleMutation(MutationOperator):
         self,
         individual: DerivationTree,
         grammar: Grammar,
-        evaluate_func: Callable[[DerivationTree], Tuple[float, list[FailingTree]]],
+        evaluate_func: Callable[[DerivationTree], tuple[float, list[FailingTree]]],
         max_nodes: int = 50,
     ) -> DerivationTree:
         """

--- a/src/fandango/evolution/population.py
+++ b/src/fandango/evolution/population.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Optional, Set, Tuple
+from typing import Callable, Optional, Set, Tuple
 
 from fandango.constraints.fitness import Comparison, ComparisonSide, FailingTree
 from fandango.language.grammar import DerivationTree, Grammar
@@ -22,7 +22,7 @@ class PopulationManager:
 
     @staticmethod
     def add_unique_individual(
-        population: List[DerivationTree],
+        population: list[DerivationTree],
         candidate: DerivationTree,
         unique_set: Set[int],
     ) -> bool:
@@ -43,9 +43,9 @@ class PopulationManager:
 
     def generate_random_population(
         self,
-        eval_individual: Callable[[DerivationTree], Tuple[float, List[FailingTree]]],
-        initial_population: Optional[List[DerivationTree]] = None,
-    ) -> List[DerivationTree]:
+        eval_individual: Callable[[DerivationTree], Tuple[float, list[FailingTree]]],
+        initial_population: Optional[list[DerivationTree]] = None,
+    ) -> list[DerivationTree]:
         """
         Generates a random population of unique individuals.
 
@@ -81,9 +81,9 @@ class PopulationManager:
 
     def refill_population(
         self,
-        current_population: List[DerivationTree],
-        eval_individual: Callable[[DerivationTree], Tuple[float, List[FailingTree]]],
-    ) -> List[DerivationTree]:
+        current_population: list[DerivationTree],
+        eval_individual: Callable[[DerivationTree], Tuple[float, list[FailingTree]]],
+    ) -> list[DerivationTree]:
         unique_hashes = {hash(ind) for ind in current_population}
         attempts = 0
         max_attempts = (self.population_size - len(current_population)) * 10
@@ -116,7 +116,7 @@ class PopulationManager:
     def fix_individual(
         self,
         individual: DerivationTree,
-        failing_trees: List[FailingTree],
+        failing_trees: list[FailingTree],
     ) -> Tuple[DerivationTree, int]:
         fixes_made = 0
         for failing_tree in failing_trees:

--- a/src/fandango/evolution/population.py
+++ b/src/fandango/evolution/population.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Set, Tuple
+from typing import Callable, Optional, Set
 
 from fandango.constraints.fitness import Comparison, ComparisonSide, FailingTree
 from fandango.language.grammar import DerivationTree, Grammar
@@ -24,7 +24,7 @@ class PopulationManager:
     def add_unique_individual(
         population: list[DerivationTree],
         candidate: DerivationTree,
-        unique_set: Set[int],
+        unique_set: set[int],
     ) -> bool:
         """
         Adds individual to the population if it is unique, according to its hash.
@@ -43,7 +43,7 @@ class PopulationManager:
 
     def generate_random_population(
         self,
-        eval_individual: Callable[[DerivationTree], Tuple[float, list[FailingTree]]],
+        eval_individual: Callable[[DerivationTree], tuple[float, list[FailingTree]]],
         initial_population: Optional[list[DerivationTree]] = None,
     ) -> list[DerivationTree]:
         """
@@ -82,7 +82,7 @@ class PopulationManager:
     def refill_population(
         self,
         current_population: list[DerivationTree],
-        eval_individual: Callable[[DerivationTree], Tuple[float, list[FailingTree]]],
+        eval_individual: Callable[[DerivationTree], tuple[float, list[FailingTree]]],
     ) -> list[DerivationTree]:
         unique_hashes = {hash(ind) for ind in current_population}
         attempts = 0
@@ -117,7 +117,7 @@ class PopulationManager:
         self,
         individual: DerivationTree,
         failing_trees: list[FailingTree],
-    ) -> Tuple[DerivationTree, int]:
+    ) -> tuple[DerivationTree, int]:
         fixes_made = 0
         for failing_tree in failing_trees:
             if failing_tree.tree.read_only:

--- a/src/fandango/evolution/profiler.py
+++ b/src/fandango/evolution/profiler.py
@@ -2,7 +2,8 @@ import time
 
 
 class Profiler:
-    def __init__(self):
+    def __init__(self, enabled: bool):
+        self.enabled = enabled
         self.metrics = {
             "initial_population": {"count": 0, "time": 0.0},
             "evaluate_population": {"count": 0, "time": 0.0},
@@ -14,11 +15,17 @@ class Profiler:
         }
 
     def start_timer(self, key: str):
+        if not self.enabled:
+            return
+
         if key not in self.metrics or not isinstance(self.metrics[key], dict):
             self.metrics[key] = {}  # Ensure it's a dictionary before adding keys
         self.metrics[key]["_start_time"] = time.time()
 
     def stop_timer(self, key: str):
+        if not self.enabled:
+            return
+
         if key not in self.metrics or not isinstance(self.metrics[key], dict):
             raise KeyError(f"Timer '{key}' was never started.")
 
@@ -33,9 +40,15 @@ class Profiler:
         self.metrics[key]["time"] += elapsed
 
     def increment(self, key: str, count: int = 1):
+        if not self.enabled:
+            return
+
         self.metrics[key]["count"] += count
 
     def log_results(self):
+        if not self.enabled:
+            return
+
         for key, value in self.metrics.items():
             if isinstance(value, dict) and "time" in value and "count" in value:
                 avg_time = value["time"] / value["count"] if value["count"] > 0 else 0

--- a/src/fandango/language/convert.py
+++ b/src/fandango/language/convert.py
@@ -1,6 +1,6 @@
 import ast
 from io import UnsupportedOperation
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from fandango.constraints.base import (
     ComparisonConstraint,
@@ -74,7 +74,7 @@ class GrammarProcessor(FandangoParserVisitor):
         self.max_repetitions = max_repetitions
 
     def get_grammar(
-        self, productions: List[FandangoParser.ProductionContext], prime=True
+        self, productions: list[FandangoParser.ProductionContext], prime=True
     ):
         grammar = Grammar(
             local_variables=self.local_variables,
@@ -192,8 +192,8 @@ class ConstraintProcessor(FandangoParserVisitor):
         self.global_variables = global_variables
 
     def get_constraints(
-        self, constraints: List[FandangoParser.ConstraintContext]
-    ) -> List[str]:
+        self, constraints: list[FandangoParser.ConstraintContext]
+    ) -> list[str]:
         return [self.visit(constraint) for constraint in constraints]
         # if len(constraints) == 1:
         #     return constraints[0]
@@ -364,7 +364,7 @@ class SearchProcessor(FandangoParserVisitor):
     def defaultResult(
         self,
     ) -> Tuple[
-        ast.AST | List[ast.AST], List[AttributeSearch], Dict[str, AttributeSearch]
+        ast.AST | list[ast.AST], list[AttributeSearch], Dict[str, AttributeSearch]
     ]:
         return [], [], {}
 
@@ -1315,7 +1315,7 @@ class PythonProcessor(FandangoParserVisitor):
     def __init__(self):
         self.search_processor = SearchProcessor(Grammar.dummy())
 
-    def get_code(self, stmts: List[FandangoParser.PythonContext]):
+    def get_code(self, stmts: list[FandangoParser.PythonContext]):
         return ast.Module(body=[self.visit(stmt) for stmt in stmts], type_ignores=[])
 
     def get_expression(self, expression):

--- a/src/fandango/language/convert.py
+++ b/src/fandango/language/convert.py
@@ -1,6 +1,6 @@
 import ast
 from io import UnsupportedOperation
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 
 from fandango.constraints.base import (
     ComparisonConstraint,
@@ -64,8 +64,8 @@ class FandangoSplitter(FandangoParserVisitor):
 class GrammarProcessor(FandangoParserVisitor):
     def __init__(
         self,
-        local_variables: Optional[Dict[str, Any]] = None,
-        global_variables: Optional[Dict[str, Any]] = None,
+        local_variables: Optional[dict[str, Any]] = None,
+        global_variables: Optional[dict[str, Any]] = None,
         max_repetitions: int = 5,
     ):
         self.local_variables = local_variables
@@ -182,8 +182,8 @@ class ConstraintProcessor(FandangoParserVisitor):
     def __init__(
         self,
         grammar: Grammar,
-        local_variables: Optional[Dict[str, Any]] = None,
-        global_variables: Optional[Dict[str, Any]] = None,
+        local_variables: Optional[dict[str, Any]] = None,
+        global_variables: Optional[dict[str, Any]] = None,
         lazy: bool = False,
     ):
         self.searches = SearchProcessor(grammar)
@@ -363,8 +363,8 @@ class SearchProcessor(FandangoParserVisitor):
 
     def defaultResult(
         self,
-    ) -> Tuple[
-        ast.AST | list[ast.AST], list[AttributeSearch], Dict[str, AttributeSearch]
+    ) -> tuple[
+        ast.AST | list[ast.AST], list[AttributeSearch], dict[str, AttributeSearch]
     ]:
         return [], [], {}
 

--- a/src/fandango/language/grammar.py
+++ b/src/fandango/language/grammar.py
@@ -804,7 +804,7 @@ class Grammar(NodeVisitor):
                 }
 
         def set_implicit_rule(
-            self, rule: list[List[NonTerminal]]
+            self, rule: list[list[NonTerminal]]
         ) -> tuple[NonTerminal, frozenset]:
             nonterminal = NonTerminal(f"<*{len(self._implicit_rules)}*>")
             self._implicit_rules[nonterminal] = rule
@@ -813,7 +813,7 @@ class Grammar(NodeVisitor):
         def set_rule(
             self,
             nonterminal: NonTerminal,
-            rule: list[List[tuple[NonTerminal, frozenset]]],
+            rule: list[list[tuple[NonTerminal, frozenset]]],
         ):
             self._rules[nonterminal] = {tuple(a) for a in rule}
 

--- a/src/fandango/language/grammar.py
+++ b/src/fandango/language/grammar.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 import exrex
 
 from copy import deepcopy
-from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union, Generator
+from typing import Any, Dict, Iterator, Optional, Set, Tuple, Union, Generator
 
 from fandango.language.symbol import NonTerminal, Symbol, Terminal
 from fandango.language.tree import DerivationTree
@@ -205,7 +205,7 @@ class Repetition(Node):
             local_cpy[name].set_all_read_only(True)
         return eval(expr, grammar._global_variables, local_cpy), False
 
-    def min(self, grammar: "Grammar", tree: "DerivationTree" = None):
+    def min(self, grammar: "Grammar", tree: Optional["DerivationTree"] = None):
         if self.static_min is None:
             current_min, is_static = self._compute_rep_bound(
                 grammar, tree, self.expr_data_min
@@ -216,7 +216,7 @@ class Repetition(Node):
         else:
             return self.static_min
 
-    def max(self, grammar: "Grammar", tree: "DerivationTree" = None):
+    def max(self, grammar: "Grammar", tree: Optional["DerivationTree"] = None):
         if self.static_max is None:
             current_max, is_static = self._compute_rep_bound(
                 grammar, tree, self.expr_data_max
@@ -439,7 +439,7 @@ class CharSet(Node):
         super().__init__(NodeType.CHAR_SET, 0)
         self.chars = chars
 
-    def fuzz(self, grammar: "Grammar", max_nodes: int = 100) -> List[DerivationTree]:
+    def fuzz(self, grammar: "Grammar", max_nodes: int = 100) -> list[DerivationTree]:
         raise NotImplementedError("CharSet fuzzing not implemented")
 
     def accept(self, visitor: "NodeVisitor"):
@@ -506,7 +506,7 @@ class Disambiguator(NodeVisitor):
 
     def visit(
         self, node: Node
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], List[Tuple[Node, ...]]]:
+    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
         if node in self.known_disambiguations:
             return self.known_disambiguations[node]
         result = super().visit(node)
@@ -515,11 +515,11 @@ class Disambiguator(NodeVisitor):
 
     def visitAlternative(
         self, node: Alternative
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], List[Tuple[Node, ...]]]:
+    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
         child_endpoints = {}
         for child in node.children():
             endpoints: Dict[
-                Tuple[Union[NonTerminal, Terminal], ...], List[Tuple[Node, ...]]
+                Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]
             ] = self.visit(child)
             for children in endpoints:
                 # prepend the alternative to all paths
@@ -534,12 +534,12 @@ class Disambiguator(NodeVisitor):
 
     def visitConcatenation(
         self, node: Concatenation
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], List[Tuple[Node, ...]]]:
+    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
         child_endpoints = {(): []}
         for child in node.children():
             next_endpoints = {}
             endpoints: Dict[
-                Tuple[Union[NonTerminal, Terminal], ...], List[Tuple[Node, ...]]
+                Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]
             ] = self.visit(child)
             for children in endpoints:
                 for existing in child_endpoints:
@@ -557,24 +557,24 @@ class Disambiguator(NodeVisitor):
 
     def visitRepetition(
         self, node: Repetition
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], List[Tuple[Node, ...]]]:
+    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
         # repetitions are alternatives over concatenations
         implicit_alternative = next(node.descendents(self.grammar))
         return self.visit(implicit_alternative)
 
     def visitStar(
         self, node: Star
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], List[Tuple[Node, ...]]]:
+    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
         return self.visitRepetition(node)
 
     def visitPlus(
         self, node: Plus
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], List[Tuple[Node, ...]]]:
+    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
         return self.visitRepetition(node)
 
     def visitOption(
         self, node: Option
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], List[Tuple[Node, ...]]]:
+    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
         implicit_alternative = Alternative(
             [Concatenation([]), Concatenation([node.node])]
         )
@@ -582,17 +582,17 @@ class Disambiguator(NodeVisitor):
 
     def visitNonTerminalNode(
         self, node: NonTerminalNode
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], List[Tuple[Node, ...]]]:
+    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
         return {(node.symbol,): [(node,)]}
 
     def visitTerminalNode(
         self, node: TerminalNode
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], List[Tuple[Node, ...]]]:
+    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
         return {(node.symbol,): [(node,)]}
 
     def visitCharSet(
         self, node: CharSet
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], List[Tuple[Node, ...]]]:
+    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
         return {(Terminal(c),): [(node, TerminalNode(Terminal(c)))] for c in node.chars}
 
 
@@ -603,7 +603,7 @@ class ParseState:
         position: int,
         symbols: Tuple[tuple[Symbol, frozenset[tuple[str, any]]], ...],
         dot: int = 0,
-        children: Optional[List[DerivationTree]] = None,
+        children: Optional[list[DerivationTree]] = None,
         is_incomplete: bool = False,
     ):
         self.nonterminal = nonterminal
@@ -670,7 +670,7 @@ class ParseState:
 
 
 class Column:
-    def __init__(self, states: Optional[List[ParseState]] = None):
+    def __init__(self, states: Optional[list[ParseState]] = None):
         self.states = states or []
         self.dot_map = dict[NonTerminal, list[ParseState]]()
         self.unique = set(self.states)
@@ -745,7 +745,7 @@ class Grammar(NodeVisitor):
         def __init__(
             self,
             symbol: Symbol,
-            children: Optional[List["DerivationTree"]] = None,
+            children: Optional[list["DerivationTree"]] = None,
             *,
             parent: Optional["DerivationTree"] = None,
             read_only: bool = False,
@@ -754,7 +754,7 @@ class Grammar(NodeVisitor):
                 symbol, children, parent=parent, sources=[], read_only=read_only
             )
 
-        def set_children(self, children: List["DerivationTree"]):
+        def set_children(self, children: list["DerivationTree"]):
             self._children = children
             self.invalidate_hash()
 
@@ -804,7 +804,7 @@ class Grammar(NodeVisitor):
                 }
 
         def set_implicit_rule(
-            self, rule: List[List[NonTerminal]]
+            self, rule: list[List[NonTerminal]]
         ) -> tuple[NonTerminal, frozenset]:
             nonterminal = NonTerminal(f"<*{len(self._implicit_rules)}*>")
             self._implicit_rules[nonterminal] = rule
@@ -813,7 +813,7 @@ class Grammar(NodeVisitor):
         def set_rule(
             self,
             nonterminal: NonTerminal,
-            rule: List[List[tuple[NonTerminal, frozenset]]],
+            rule: list[List[tuple[NonTerminal, frozenset]]],
         ):
             self._rules[nonterminal] = {tuple(a) for a in rule}
 
@@ -859,8 +859,8 @@ class Grammar(NodeVisitor):
         def visitRepetition(
             self,
             node: Repetition,
-            nt: tuple[NonTerminal, frozenset] = None,
-            tree: DerivationTree = None,
+            nt: Optional[tuple[NonTerminal, frozenset]] = None,
+            tree: Optional[DerivationTree] = None,
         ):
             if nt is None:
                 alternatives = self.visit(node.node)
@@ -955,7 +955,7 @@ class Grammar(NodeVisitor):
             ]
 
         def predict(
-            self, state: ParseState, table: List[Set[ParseState] | Column], k: int
+            self, state: ParseState, table: list[Set[ParseState] | Column], k: int
         ):
             if state.dot in self._rules:
                 table[k].update(
@@ -976,7 +976,7 @@ class Grammar(NodeVisitor):
                 self.predict_ctx_rule(state, table, k, node, nt)
 
         def construct_incomplete_tree(
-            self, state: ParseState, table: List[Set[ParseState] | Column]
+            self, state: ParseState, table: list[Set[ParseState] | Column]
         ) -> DerivationTree:
             current_tree = Grammar.ParserDerivationTree(
                 state.nonterminal, state.children
@@ -1008,7 +1008,7 @@ class Grammar(NodeVisitor):
         def predict_ctx_rule(
             self,
             state: ParseState,
-            table: List[Set[ParseState] | Column],
+            table: list[Set[ParseState] | Column],
             k: int,
             node: Node,
             nt_rule,
@@ -1050,7 +1050,7 @@ class Grammar(NodeVisitor):
             self,
             state: ParseState,
             word: str | bytes,
-            table: List[Set[ParseState] | Column],
+            table: list[Set[ParseState] | Column],
             k: int,
             w: int,
             bit_count: int,
@@ -1105,7 +1105,7 @@ class Grammar(NodeVisitor):
             self,
             state: ParseState,
             word: str | bytes,
-            table: List[Set[ParseState] | Column],
+            table: list[Set[ParseState] | Column],
             k: int,
             w: int,
         ) -> bool:
@@ -1143,7 +1143,7 @@ class Grammar(NodeVisitor):
             self,
             state: ParseState,
             word: str | bytes,
-            table: List[Set[ParseState] | Column],
+            table: list[Set[ParseState] | Column],
             k: int,
             w: int,
         ) -> bool:
@@ -1204,7 +1204,7 @@ class Grammar(NodeVisitor):
         def complete(
             self,
             state: ParseState,
-            table: List[Set[ParseState] | Column],
+            table: list[Set[ParseState] | Column],
             k: int,
             use_implicit: bool = False,
         ):
@@ -1230,7 +1230,7 @@ class Grammar(NodeVisitor):
                     else:
                         s.children.extend(state.children)
 
-        def place_repetition_shortcut(self, table: List[Column], k: int):
+        def place_repetition_shortcut(self, table: list[Column], k: int):
             col = table[k]
             states = col.states
             beginner_nts = ["<__plus:", "<__star:"]
@@ -1597,7 +1597,7 @@ class Grammar(NodeVisitor):
     def generate_string(
         self,
         symbol: str | NonTerminal = "<start>",
-        sources: list[DerivationTree] = None,
+        sources: Optional[list[DerivationTree]] = None,
     ) -> tuple[list[DerivationTree], str]:
         if isinstance(symbol, str):
             symbol = NonTerminal(symbol)
@@ -1812,7 +1812,7 @@ class Grammar(NodeVisitor):
         self._parser = Grammar.Parser(self)
 
     def compute_kpath_coverage(
-        self, derivation_trees: List[DerivationTree], k: int
+        self, derivation_trees: list[DerivationTree], k: int
     ) -> float:
         """
         Computes the k-path coverage of the grammar given a set of derivation trees.
@@ -1848,7 +1848,7 @@ class Grammar(NodeVisitor):
             initial.add(node)
             initial_work.extend(node.descendents(self))
 
-        work: List[Set[Tuple[Node]]] = [set((x,) for x in initial)]
+        work: list[Set[Tuple[Node]]] = [set((x,) for x in initial)]
 
         for _ in range(1, k):
             next_work = set()
@@ -1971,9 +1971,9 @@ class Grammar(NodeVisitor):
     def traverse_derivation(
         self,
         tree: DerivationTree,
-        disambiguator: Disambiguator = None,
-        paths: Set[Tuple[Node, ...]] = None,
-        cur_path: Tuple[Node, ...] = None,
+        disambiguator: Optional[Disambiguator] = None,
+        paths: Optional[Set[Tuple[Node, ...]]] = None,
+        cur_path: Optional[Tuple[Node, ...]] = None,
     ) -> Set[Tuple[Node, ...]]:
         if disambiguator is None:
             disambiguator = Disambiguator(self)
@@ -1995,7 +1995,7 @@ class Grammar(NodeVisitor):
         return paths
 
     def compute_grammar_coverage(
-        self, derivation_trees: List[DerivationTree], k: int
+        self, derivation_trees: list[DerivationTree], k: int
     ) -> Tuple[float, int, int]:
         """
         Compute the coverage of k-paths in the grammar based on the given derivation trees.

--- a/src/fandango/language/grammar.py
+++ b/src/fandango/language/grammar.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 import exrex
 
 from copy import deepcopy
-from typing import Any, Dict, Iterator, Optional, Set, Tuple, Union, Generator
+from typing import Any, Iterator, Optional, Set, Union, Generator
 
 from fandango.language.symbol import NonTerminal, Symbol, Terminal
 from fandango.language.tree import DerivationTree
@@ -506,7 +506,7 @@ class Disambiguator(NodeVisitor):
 
     def visit(
         self, node: Node
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
+    ) -> dict[tuple[Union[NonTerminal, Terminal], ...], list[tuple[Node, ...]]]:
         if node in self.known_disambiguations:
             return self.known_disambiguations[node]
         result = super().visit(node)
@@ -515,11 +515,11 @@ class Disambiguator(NodeVisitor):
 
     def visitAlternative(
         self, node: Alternative
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
+    ) -> dict[tuple[Union[NonTerminal, Terminal], ...], list[tuple[Node, ...]]]:
         child_endpoints = {}
         for child in node.children():
-            endpoints: Dict[
-                Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]
+            endpoints: dict[
+                tuple[Union[NonTerminal, Terminal], ...], list[tuple[Node, ...]]
             ] = self.visit(child)
             for children in endpoints:
                 # prepend the alternative to all paths
@@ -534,12 +534,12 @@ class Disambiguator(NodeVisitor):
 
     def visitConcatenation(
         self, node: Concatenation
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
+    ) -> dict[tuple[Union[NonTerminal, Terminal], ...], list[tuple[Node, ...]]]:
         child_endpoints = {(): []}
         for child in node.children():
             next_endpoints = {}
-            endpoints: Dict[
-                Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]
+            endpoints: dict[
+                tuple[Union[NonTerminal, Terminal], ...], list[tuple[Node, ...]]
             ] = self.visit(child)
             for children in endpoints:
                 for existing in child_endpoints:
@@ -557,24 +557,24 @@ class Disambiguator(NodeVisitor):
 
     def visitRepetition(
         self, node: Repetition
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
+    ) -> dict[tuple[Union[NonTerminal, Terminal], ...], list[tuple[Node, ...]]]:
         # repetitions are alternatives over concatenations
         implicit_alternative = next(node.descendents(self.grammar))
         return self.visit(implicit_alternative)
 
     def visitStar(
         self, node: Star
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
+    ) -> dict[tuple[Union[NonTerminal, Terminal], ...], list[tuple[Node, ...]]]:
         return self.visitRepetition(node)
 
     def visitPlus(
         self, node: Plus
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
+    ) -> dict[tuple[Union[NonTerminal, Terminal], ...], list[tuple[Node, ...]]]:
         return self.visitRepetition(node)
 
     def visitOption(
         self, node: Option
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
+    ) -> dict[tuple[Union[NonTerminal, Terminal], ...], list[tuple[Node, ...]]]:
         implicit_alternative = Alternative(
             [Concatenation([]), Concatenation([node.node])]
         )
@@ -582,17 +582,17 @@ class Disambiguator(NodeVisitor):
 
     def visitNonTerminalNode(
         self, node: NonTerminalNode
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
+    ) -> dict[tuple[Union[NonTerminal, Terminal], ...], list[tuple[Node, ...]]]:
         return {(node.symbol,): [(node,)]}
 
     def visitTerminalNode(
         self, node: TerminalNode
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
+    ) -> dict[tuple[Union[NonTerminal, Terminal], ...], list[tuple[Node, ...]]]:
         return {(node.symbol,): [(node,)]}
 
     def visitCharSet(
         self, node: CharSet
-    ) -> Dict[Tuple[Union[NonTerminal, Terminal], ...], list[Tuple[Node, ...]]]:
+    ) -> dict[tuple[Union[NonTerminal, Terminal], ...], list[tuple[Node, ...]]]:
         return {(Terminal(c),): [(node, TerminalNode(Terminal(c)))] for c in node.chars}
 
 
@@ -601,7 +601,7 @@ class ParseState:
         self,
         nonterminal: NonTerminal,
         position: int,
-        symbols: Tuple[tuple[Symbol, frozenset[tuple[str, any]]], ...],
+        symbols: tuple[tuple[Symbol, frozenset[tuple[str, any]]], ...],
         dot: int = 0,
         children: Optional[list[DerivationTree]] = None,
         is_incomplete: bool = False,
@@ -721,7 +721,7 @@ class Column:
             return True
         return False
 
-    def update(self, states: Set[ParseState]):
+    def update(self, states: set[ParseState]):
         for state in states:
             self.add(state)
 
@@ -767,7 +767,7 @@ class Grammar(NodeVisitor):
             self,
             grammar: "Grammar",
         ):
-            self.grammar_rules: Dict[NonTerminal, Node] = grammar.rules
+            self.grammar_rules: dict[NonTerminal, Node] = grammar.rules
             self.grammar = grammar
             self._rules = {}
             self._implicit_rules = {}
@@ -781,7 +781,7 @@ class Grammar(NodeVisitor):
             self.plus_count = 0
             self.option_count = 0
             self._process()
-            self._cache: Dict[Tuple[str, NonTerminal], DerivationTree, bool] = {}
+            self._cache: dict[tuple[str, NonTerminal], DerivationTree, bool] = {}
             self._incomplete = set()
             self._max_position = -1
 
@@ -955,7 +955,7 @@ class Grammar(NodeVisitor):
             ]
 
         def predict(
-            self, state: ParseState, table: list[Set[ParseState] | Column], k: int
+            self, state: ParseState, table: list[set[ParseState] | Column], k: int
         ):
             if state.dot in self._rules:
                 table[k].update(
@@ -976,7 +976,7 @@ class Grammar(NodeVisitor):
                 self.predict_ctx_rule(state, table, k, node, nt)
 
         def construct_incomplete_tree(
-            self, state: ParseState, table: list[Set[ParseState] | Column]
+            self, state: ParseState, table: list[set[ParseState] | Column]
         ) -> DerivationTree:
             current_tree = Grammar.ParserDerivationTree(
                 state.nonterminal, state.children
@@ -1008,7 +1008,7 @@ class Grammar(NodeVisitor):
         def predict_ctx_rule(
             self,
             state: ParseState,
-            table: list[Set[ParseState] | Column],
+            table: list[set[ParseState] | Column],
             k: int,
             node: Node,
             nt_rule,
@@ -1050,7 +1050,7 @@ class Grammar(NodeVisitor):
             self,
             state: ParseState,
             word: str | bytes,
-            table: list[Set[ParseState] | Column],
+            table: list[set[ParseState] | Column],
             k: int,
             w: int,
             bit_count: int,
@@ -1105,7 +1105,7 @@ class Grammar(NodeVisitor):
             self,
             state: ParseState,
             word: str | bytes,
-            table: list[Set[ParseState] | Column],
+            table: list[set[ParseState] | Column],
             k: int,
             w: int,
         ) -> bool:
@@ -1143,7 +1143,7 @@ class Grammar(NodeVisitor):
             self,
             state: ParseState,
             word: str | bytes,
-            table: list[Set[ParseState] | Column],
+            table: list[set[ParseState] | Column],
             k: int,
             w: int,
         ) -> bool:
@@ -1204,7 +1204,7 @@ class Grammar(NodeVisitor):
         def complete(
             self,
             state: ParseState,
-            table: list[Set[ParseState] | Column],
+            table: list[set[ParseState] | Column],
             k: int,
             use_implicit: bool = False,
         ):
@@ -1484,12 +1484,12 @@ class Grammar(NodeVisitor):
 
     def __init__(
         self,
-        rules: Optional[Dict[NonTerminal, Node]] = None,
-        local_variables: Optional[Dict[str, Any]] = None,
-        global_variables: Optional[Dict[str, Any]] = None,
+        rules: Optional[dict[NonTerminal, Node]] = None,
+        local_variables: Optional[dict[str, Any]] = None,
+        global_variables: Optional[dict[str, Any]] = None,
     ):
         self.rules = rules or {}
-        self.generators: Dict[NonTerminal, LiteralGenerator] = {}
+        self.generators: dict[NonTerminal, LiteralGenerator] = {}
         self._parser = Grammar.Parser(self)
         self._local_variables = local_variables or {}
         self._global_variables = global_variables or {}
@@ -1676,7 +1676,7 @@ class Grammar(NodeVisitor):
         root._parent = None
         return root
 
-    def update(self, grammar: "Grammar" | Dict[NonTerminal, Node], prime=True):
+    def update(self, grammar: Union["Grammar", dict[NonTerminal, Node]], prime=True):
         if isinstance(grammar, Grammar):
             generators = grammar.generators
             local_variables = grammar._local_variables
@@ -1831,7 +1831,7 @@ class Grammar(NodeVisitor):
             return 1.0  # If there are no k-paths, coverage is 100%
         return len(covered_k_paths) / len(all_k_paths)
 
-    def _generate_all_k_paths(self, k: int) -> Set[Tuple[Node, ...]]:
+    def _generate_all_k_paths(self, k: int) -> set[tuple[Node, ...]]:
         """
         Computes the *k*-paths for this grammar, constructively. See: doi.org/10.1109/ASE.2019.00027
 
@@ -1848,7 +1848,7 @@ class Grammar(NodeVisitor):
             initial.add(node)
             initial_work.extend(node.descendents(self))
 
-        work: list[Set[Tuple[Node]]] = [set((x,) for x in initial)]
+        work: list[set[tuple[Node]]] = [set((x,) for x in initial)]
 
         for _ in range(1, k):
             next_work = set()
@@ -1863,13 +1863,13 @@ class Grammar(NodeVisitor):
     @staticmethod
     def _extract_k_paths_from_tree(
         tree: DerivationTree, k: int
-    ) -> Set[Tuple[Node, ...]]:
+    ) -> set[tuple[Node, ...]]:
         """
         Extracts all k-length paths (k-paths) from a derivation tree.
         """
         paths = set()
 
-        def traverse(node: DerivationTree, current_path: Tuple[str, ...]):
+        def traverse(node: DerivationTree, current_path: tuple[str, ...]):
             new_path = current_path + (node.symbol.symbol,)
             if len(new_path) == k:
                 paths.add(new_path)
@@ -1959,7 +1959,7 @@ class Grammar(NodeVisitor):
     def visitCharSet(self, node: CharSet):
         return []
 
-    def compute_k_paths(self, k: int) -> Set[Tuple[Node, ...]]:
+    def compute_k_paths(self, k: int) -> set[tuple[Node, ...]]:
         """
         Computes all possible k-paths in the grammar.
 
@@ -1972,9 +1972,9 @@ class Grammar(NodeVisitor):
         self,
         tree: DerivationTree,
         disambiguator: Optional[Disambiguator] = None,
-        paths: Optional[Set[Tuple[Node, ...]]] = None,
-        cur_path: Optional[Tuple[Node, ...]] = None,
-    ) -> Set[Tuple[Node, ...]]:
+        paths: Optional[set[tuple[Node, ...]]] = None,
+        cur_path: Optional[tuple[Node, ...]] = None,
+    ) -> set[tuple[Node, ...]]:
         if disambiguator is None:
             disambiguator = Disambiguator(self)
         if paths is None:
@@ -1996,7 +1996,7 @@ class Grammar(NodeVisitor):
 
     def compute_grammar_coverage(
         self, derivation_trees: list[DerivationTree], k: int
-    ) -> Tuple[float, int, int]:
+    ) -> tuple[float, int, int]:
         """
         Compute the coverage of k-paths in the grammar based on the given derivation trees.
 

--- a/src/fandango/language/parse.py
+++ b/src/fandango/language/parse.py
@@ -9,7 +9,7 @@ import re
 from copy import deepcopy
 from pathlib import Path
 from io import StringIO
-from typing import IO, Any, List, Optional, Set, Tuple
+from typing import IO, Any, Optional, Set, Tuple
 
 import cachedir_tag
 import dill as pickle
@@ -61,13 +61,13 @@ class MyErrorListener(ErrorListener):
 CURRENT_FILENAME: str = "<undefined>"
 
 # The list of directories to search for include files
-INCLUDES: List[str] = []
+INCLUDES: list[str] = []
 
 # The list of files to parse, with their include depth.
 # An include depth of 0 means the file was given as input.
 # A higher include depth means the file was included from another file;
 # hence its grammar and constraints should be processed _before_ the current file.
-FILES_TO_PARSE: List[Tuple[IO, int]] = []
+FILES_TO_PARSE: list[Tuple[IO, int]] = []
 
 # The current include depth
 INCLUDE_DEPTH: int = 0
@@ -173,7 +173,7 @@ class FandangoSpec:
             global_variables=self.global_vars,
             lazy=self.lazy,
         )
-        self.constraints: List[str] = constraint_processor.get_constraints(
+        self.constraints: list[str] = constraint_processor.get_constraints(
             splitter.constraints
         )
 
@@ -205,7 +205,7 @@ def parse_content(
     use_cache: bool = True,
     lazy: bool = False,
     max_repetitions: int = 5,
-) -> Tuple[Grammar, List[str]]:
+) -> Tuple[Grammar, list[str]]:
     """
     Parse given content into a grammar and constraints.
     This is a helper function; use `parse()` as the main entry point.
@@ -306,21 +306,21 @@ USED_SYMBOLS: Set[str] = set()
 
 # Save the standard library grammar and constraints
 STDLIB_GRAMMAR: Optional[Grammar] = None
-STDLIB_CONSTRAINTS: Optional[List[str]] = None
+STDLIB_CONSTRAINTS: Optional[list[str]] = None
 
 
 def parse(
-    fan_files: str | IO | List[str | IO],
-    constraints: List[str] = None,
+    fan_files: str | IO | list[str | IO],
+    constraints: Optional[list[str]] = None,
     *,
     use_cache: bool = True,
     use_stdlib: bool = True,
     lazy: bool = False,
-    given_grammars: List[Grammar] = [],
+    given_grammars: list[Grammar] = [],
     start_symbol: Optional[str] = None,
-    includes: List[str] = [],
+    includes: list[str] = [],
     max_repetitions: int = 5,
-) -> Tuple[Optional[Grammar], List[str]]:
+) -> Tuple[Optional[Grammar], list[str]]:
     """
     Parse .fan content, handling multiple files, standard library, and includes.
     :param fan_files: One (open) .fan file, one string, or a list of these
@@ -372,7 +372,7 @@ def parse(
     INCLUDES = includes
 
     grammars = []
-    parsed_constraints: List[str] = []
+    parsed_constraints: list[str] = []
     if use_stdlib:
         assert STDLIB_GRAMMAR is not None
         assert STDLIB_CONSTRAINTS is not None

--- a/src/fandango/language/parse.py
+++ b/src/fandango/language/parse.py
@@ -9,7 +9,7 @@ import re
 from copy import deepcopy
 from pathlib import Path
 from io import StringIO
-from typing import IO, Any, Optional, Set, Tuple
+from typing import Any, IO, Optional
 
 import cachedir_tag
 import dill as pickle
@@ -67,7 +67,7 @@ INCLUDES: list[str] = []
 # An include depth of 0 means the file was given as input.
 # A higher include depth means the file was included from another file;
 # hence its grammar and constraints should be processed _before_ the current file.
-FILES_TO_PARSE: list[Tuple[IO, int]] = []
+FILES_TO_PARSE: list[tuple[IO, int]] = []
 
 # The current include depth
 INCLUDE_DEPTH: int = 0
@@ -205,7 +205,7 @@ def parse_content(
     use_cache: bool = True,
     lazy: bool = False,
     max_repetitions: int = 5,
-) -> Tuple[Grammar, list[str]]:
+) -> tuple[Grammar, list[str]]:
     """
     Parse given content into a grammar and constraints.
     This is a helper function; use `parse()` as the main entry point.
@@ -302,7 +302,7 @@ def parse_content(
 
 
 # Save the set of symbols used in the standard library and imported grammars
-USED_SYMBOLS: Set[str] = set()
+USED_SYMBOLS: set[str] = set()
 
 # Save the standard library grammar and constraints
 STDLIB_GRAMMAR: Optional[Grammar] = None
@@ -320,7 +320,7 @@ def parse(
     start_symbol: Optional[str] = None,
     includes: list[str] = [],
     max_repetitions: int = 5,
-) -> Tuple[Optional[Grammar], list[str]]:
+) -> tuple[Optional[Grammar], list[str]]:
     """
     Parse .fan content, handling multiple files, standard library, and includes.
     :param fan_files: One (open) .fan file, one string, or a list of these

--- a/src/fandango/language/search.py
+++ b/src/fandango/language/search.py
@@ -137,12 +137,12 @@ class NonTerminalSearch(abc.ABC):
         self,
         trees: list[DerivationTree],
         scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
-    ) -> list[List[Container]]:
+    ) -> list[list[Container]]:
         """
         Find all the non-terminals in the list of derivation trees that match the search criteria.
         :param list[DerivationTree] trees: The list of derivation trees.
         :param Optional[Dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
-        :return list[List[Container]]: The list of lists of containers that hold the matching derivation trees.
+        :return list[list[Container]]: The list of lists of containers that hold the matching derivation trees.
         """
         targets = []
         for tree in trees:

--- a/src/fandango/language/search.py
+++ b/src/fandango/language/search.py
@@ -4,7 +4,7 @@ search criteria.
 """
 
 import abc
-from typing import Optional, Dict, Tuple, Any
+from typing import Any, Optional
 
 from fandango.language.symbol import NonTerminal
 from fandango.language.tree import DerivationTree
@@ -111,12 +111,12 @@ class NonTerminalSearch(abc.ABC):
     def find(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[Container]:
         """
         Find all the non-terminals in the derivation tree that match the search criteria.
         :param DerivationTree tree: The derivation tree.
-        :param Optional[Dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
+        :param Optional[dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
         :return list[Container]: The list of containers that hold the matching derivation trees.
         """
 
@@ -124,24 +124,24 @@ class NonTerminalSearch(abc.ABC):
     def find_direct(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[Container]:
         """
         Find the direct-child non-terminals in the derivation tree that match the search criteria.
         :param DerivationTree tree: The derivation tree.
-        :param Optional[Dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
+        :param Optional[dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
         :return list[Container]: The list of containers that hold the matching derivation trees.
         """
 
     def find_all(
         self,
         trees: list[DerivationTree],
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[list[Container]]:
         """
         Find all the non-terminals in the list of derivation trees that match the search criteria.
         :param list[DerivationTree] trees: The list of derivation trees.
-        :param Optional[Dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
+        :param Optional[dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
         :return list[list[Container]]: The list of lists of containers that hold the matching derivation trees.
         """
         targets = []
@@ -179,7 +179,7 @@ class LengthSearch(NonTerminalSearch):
     def find(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[Container]:
         ret = [
             Length(
@@ -198,7 +198,7 @@ class LengthSearch(NonTerminalSearch):
     def find_direct(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[Container]:
         ret = [
             Length(
@@ -239,7 +239,7 @@ class RuleSearch(NonTerminalSearch):
     def find(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[Container]:
         if scope and self.symbol in scope:
             ret = [Tree(scope[self.symbol])]
@@ -252,7 +252,7 @@ class RuleSearch(NonTerminalSearch):
     def find_direct(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[Container]:
         if scope and self.symbol in scope:
             ret = [Tree(scope[self.symbol])]
@@ -290,7 +290,7 @@ class AttributeSearch(NonTerminalSearch):
     def find(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[Container]:
         bases = self.base.find(tree, scope=scope)
         targets = []
@@ -303,7 +303,7 @@ class AttributeSearch(NonTerminalSearch):
     def find_direct(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[Container]:
         bases = self.base.find_direct(tree, scope=scope)
         targets = []
@@ -341,7 +341,7 @@ class DescendantAttributeSearch(NonTerminalSearch):
     def find(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[Container]:
         bases = self.base.find(tree, scope=scope)
         targets = []
@@ -355,7 +355,7 @@ class DescendantAttributeSearch(NonTerminalSearch):
     def find_direct(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[Container]:
         bases = self.base.find_direct(tree, scope=scope)
         targets = []
@@ -381,11 +381,11 @@ class ItemSearch(NonTerminalSearch):
     Non-terminal search that finds the non-terminals that get the items from the base non-terminal.
     """
 
-    def __init__(self, base: NonTerminalSearch, slices: Tuple[Any] | slice | int):
+    def __init__(self, base: NonTerminalSearch, slices: tuple[Any] | slice | int):
         """
         Initialize the ItemSearch with the given base and slices.
         :param NonTerminalSearch base: The base non-terminal
-        :param Tuple[Any] slices: The slices to get the items from the base non-terminal.
+        :param tuple[Any] slices: The slices to get the items from the base non-terminal.
         """
         self.base = base
         self.slices = slices
@@ -405,14 +405,14 @@ class ItemSearch(NonTerminalSearch):
     def find(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[Container]:
         return self._find(self.base.find(tree, scope=scope))
 
     def find_direct(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[Container]:
         return self._find(self.base.find_direct(tree, scope=scope))
 
@@ -462,13 +462,13 @@ class SelectiveSearch(NonTerminalSearch):
     def __init__(
         self,
         base: NonTerminalSearch,
-        symbols: list[Tuple[NonTerminal, bool]],
+        symbols: list[tuple[NonTerminal, bool]],
         slices: list[Optional[Any]] = None,
     ):
         """
         Initialize the SelectiveSearch with the given base, symbols, and slices.
         :param NonTerminalSearch base: The base non-terminal search.
-        :param list[Tuple[NonTerminal, bool]] symbols: The list of symbols and whether to find direct or all trees.
+        :param list[tuple[NonTerminal, bool]] symbols: The list of symbols and whether to find direct or all trees.
         :param list[Optional[Any]] slices: The list of slices to get the items from the symbols.
         """
         self.base = base
@@ -498,7 +498,7 @@ class SelectiveSearch(NonTerminalSearch):
     def find(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[Container]:
         ret = self._find(self.base.find(tree, scope=scope))
         # LOGGER.debug(f"SelectiveSearch({self}).find({tree.value()!r}) = {ret}")
@@ -507,7 +507,7 @@ class SelectiveSearch(NonTerminalSearch):
     def find_direct(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+        scope: Optional[dict[NonTerminal, list[DerivationTree]]] = None,
     ) -> list[Container]:
         ret = self._find(self.base.find_direct(tree, scope=scope))
         # LOGGER.debug(f"SelectiveSearch({self}).find_direct({tree.value()!r}) = {ret}")

--- a/src/fandango/language/search.py
+++ b/src/fandango/language/search.py
@@ -4,7 +4,7 @@ search criteria.
 """
 
 import abc
-from typing import List, Optional, Dict, Tuple, Any
+from typing import Optional, Dict, Tuple, Any
 
 from fandango.language.symbol import NonTerminal
 from fandango.language.tree import DerivationTree
@@ -19,10 +19,10 @@ class Container(abc.ABC):
     """
 
     @abc.abstractmethod
-    def get_trees(self) -> List[DerivationTree]:
+    def get_trees(self) -> list[DerivationTree]:
         """
         Get the list of derivation trees in the container.
-        :return List[DerivationTree]: The list of derivation trees.
+        :return list[DerivationTree]: The list of derivation trees.
         """
         pass
 
@@ -47,10 +47,10 @@ class Tree(Container):
         """
         self.tree = tree
 
-    def get_trees(self) -> List[DerivationTree]:
+    def get_trees(self) -> list[DerivationTree]:
         """
         Get the list of derivation trees in the container.
-        :return List[DerivationTree]: The list of derivation trees.
+        :return list[DerivationTree]: The list of derivation trees.
         """
         return [self.tree]
 
@@ -73,17 +73,17 @@ class Length(Container):
     Container that holds a list of derivation trees and evaluates to the length of the list.
     """
 
-    def __init__(self, trees: List[DerivationTree]):
+    def __init__(self, trees: list[DerivationTree]):
         """
         Initialize the Tree container with the given derivation trees.
-        :param List[DerivationTree] trees: The list of derivation trees.
+        :param list[DerivationTree] trees: The list of derivation trees.
         """
         self.trees = trees
 
-    def get_trees(self) -> List[DerivationTree]:
+    def get_trees(self) -> list[DerivationTree]:
         """
         Get the list of derivation trees in the container.
-        :return List[DerivationTree]: The list of derivation trees.
+        :return list[DerivationTree]: The list of derivation trees.
         """
         return self.trees
 
@@ -111,38 +111,38 @@ class NonTerminalSearch(abc.ABC):
     def find(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[Container]:
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[Container]:
         """
         Find all the non-terminals in the derivation tree that match the search criteria.
         :param DerivationTree tree: The derivation tree.
-        :param Optional[Dict[NonTerminal, List[DerivationTree]]] scope: The scope of non-terminals matching to trees.
-        :return List[Container]: The list of containers that hold the matching derivation trees.
+        :param Optional[Dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
+        :return list[Container]: The list of containers that hold the matching derivation trees.
         """
 
     @abc.abstractmethod
     def find_direct(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[Container]:
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[Container]:
         """
         Find the direct-child non-terminals in the derivation tree that match the search criteria.
         :param DerivationTree tree: The derivation tree.
-        :param Optional[Dict[NonTerminal, List[DerivationTree]]] scope: The scope of non-terminals matching to trees.
-        :return List[Container]: The list of containers that hold the matching derivation trees.
+        :param Optional[Dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
+        :return list[Container]: The list of containers that hold the matching derivation trees.
         """
 
     def find_all(
         self,
-        trees: List[DerivationTree],
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[List[Container]]:
+        trees: list[DerivationTree],
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[List[Container]]:
         """
         Find all the non-terminals in the list of derivation trees that match the search criteria.
-        :param List[DerivationTree] trees: The list of derivation trees.
-        :param Optional[Dict[NonTerminal, List[DerivationTree]]] scope: The scope of non-terminals matching to trees.
-        :return List[List[Container]]: The list of lists of containers that hold the matching derivation trees.
+        :param list[DerivationTree] trees: The list of derivation trees.
+        :param Optional[Dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
+        :return list[List[Container]]: The list of lists of containers that hold the matching derivation trees.
         """
         targets = []
         for tree in trees:
@@ -157,10 +157,10 @@ class NonTerminalSearch(abc.ABC):
         return self.__repr__()
 
     @abc.abstractmethod
-    def get_access_points(self) -> List[NonTerminal]:
+    def get_access_points(self) -> list[NonTerminal]:
         """
         Get the access points of the non-terminal search, i.e., the non-terminal that are considered in this search.
-        :return List[NonTerminal]: The list of access points.
+        :return list[NonTerminal]: The list of access points.
         """
 
 
@@ -179,8 +179,8 @@ class LengthSearch(NonTerminalSearch):
     def find(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[Container]:
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[Container]:
         ret = [
             Length(
                 sum(
@@ -198,8 +198,8 @@ class LengthSearch(NonTerminalSearch):
     def find_direct(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[Container]:
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[Container]:
         ret = [
             Length(
                 sum(
@@ -239,8 +239,8 @@ class RuleSearch(NonTerminalSearch):
     def find(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[Container]:
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[Container]:
         if scope and self.symbol in scope:
             ret = [Tree(scope[self.symbol])]
         else:
@@ -252,8 +252,8 @@ class RuleSearch(NonTerminalSearch):
     def find_direct(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[Container]:
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[Container]:
         if scope and self.symbol in scope:
             ret = [Tree(scope[self.symbol])]
         else:
@@ -290,8 +290,8 @@ class AttributeSearch(NonTerminalSearch):
     def find(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[Container]:
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[Container]:
         bases = self.base.find(tree, scope=scope)
         targets = []
         for base in bases:
@@ -303,8 +303,8 @@ class AttributeSearch(NonTerminalSearch):
     def find_direct(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[Container]:
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[Container]:
         bases = self.base.find_direct(tree, scope=scope)
         targets = []
         for base in bases:
@@ -341,8 +341,8 @@ class DescendantAttributeSearch(NonTerminalSearch):
     def find(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[Container]:
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[Container]:
         bases = self.base.find(tree, scope=scope)
         targets = []
         for base in bases:
@@ -355,8 +355,8 @@ class DescendantAttributeSearch(NonTerminalSearch):
     def find_direct(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[Container]:
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[Container]:
         bases = self.base.find_direct(tree, scope=scope)
         targets = []
         for base in bases:
@@ -390,7 +390,7 @@ class ItemSearch(NonTerminalSearch):
         self.base = base
         self.slices = slices
 
-    def _find(self, bases: List[Container]):
+    def _find(self, bases: list[Container]):
         return list(
             map(
                 Tree,
@@ -405,15 +405,15 @@ class ItemSearch(NonTerminalSearch):
     def find(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[Container]:
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[Container]:
         return self._find(self.base.find(tree, scope=scope))
 
     def find_direct(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[Container]:
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[Container]:
         return self._find(self.base.find_direct(tree, scope=scope))
 
     def __repr__(self):
@@ -462,20 +462,20 @@ class SelectiveSearch(NonTerminalSearch):
     def __init__(
         self,
         base: NonTerminalSearch,
-        symbols: List[Tuple[NonTerminal, bool]],
-        slices: List[Optional[Any]] = None,
+        symbols: list[Tuple[NonTerminal, bool]],
+        slices: list[Optional[Any]] = None,
     ):
         """
         Initialize the SelectiveSearch with the given base, symbols, and slices.
         :param NonTerminalSearch base: The base non-terminal search.
-        :param List[Tuple[NonTerminal, bool]] symbols: The list of symbols and whether to find direct or all trees.
-        :param List[Optional[Any]] slices: The list of slices to get the items from the symbols.
+        :param list[Tuple[NonTerminal, bool]] symbols: The list of symbols and whether to find direct or all trees.
+        :param list[Optional[Any]] slices: The list of slices to get the items from the symbols.
         """
         self.base = base
         self.symbols = symbols
         self.slices = slices or [None] * len(symbols)
 
-    def _find(self, bases: List[Container]):
+    def _find(self, bases: list[Container]):
         result = []
         for symbol, is_direct, items in zip(*zip(*self.symbols), self.slices):
             if is_direct:
@@ -498,8 +498,8 @@ class SelectiveSearch(NonTerminalSearch):
     def find(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[Container]:
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[Container]:
         ret = self._find(self.base.find(tree, scope=scope))
         # LOGGER.debug(f"SelectiveSearch({self}).find({tree.value()!r}) = {ret}")
         return ret
@@ -507,8 +507,8 @@ class SelectiveSearch(NonTerminalSearch):
     def find_direct(
         self,
         tree: DerivationTree,
-        scope: Optional[Dict[NonTerminal, List[DerivationTree]]] = None,
-    ) -> List[Container]:
+        scope: Optional[Dict[NonTerminal, list[DerivationTree]]] = None,
+    ) -> list[Container]:
         ret = self._find(self.base.find_direct(tree, scope=scope))
         # LOGGER.debug(f"SelectiveSearch({self}).find_direct({tree.value()!r}) = {ret}")
         return ret

--- a/src/fandango/language/server/language_server.py
+++ b/src/fandango/language/server/language_server.py
@@ -1,7 +1,7 @@
 from antlr4 import InputStream, Token
 from pygls.server import LanguageServer
 import lsprotocol.types as lsp
-from typing import Dict, Optional, List
+from typing import Dict, Optional,  
 import logging
 from fandango.language.parser.FandangoLexer import FandangoLexer
 from fandango.language.server.semantic_tokens import (
@@ -12,7 +12,7 @@ from fandango.language.server.semantic_tokens import (
 logger = logging.getLogger(__name__)
 
 
-def map_to_ranges(references: List[Token], uri: str):
+def map_to_ranges(references: list[Token], uri: str):
     return [
         lsp.Range(
             start=lsp.Position(line=t.line - 1, character=t.column),
@@ -22,7 +22,7 @@ def map_to_ranges(references: List[Token], uri: str):
     ]
 
 
-def map_to_locations(references: List[Token], uri: str):
+def map_to_locations(references: list[Token], uri: str):
     locations = [
         lsp.Location(
             uri=uri,
@@ -36,7 +36,7 @@ def map_to_locations(references: List[Token], uri: str):
 
 class FileAssets:
     def __init__(self, lexer: FandangoLexer):
-        self.tokens: List[Token] = lexer.getAllTokens()
+        self.tokens: list[Token] = lexer.getAllTokens()
 
 
 class FandangoLanguageServer(LanguageServer):

--- a/src/fandango/language/server/language_server.py
+++ b/src/fandango/language/server/language_server.py
@@ -1,7 +1,7 @@
 from antlr4 import InputStream, Token
 from pygls.server import LanguageServer
 import lsprotocol.types as lsp
-from typing import Dict, Optional
+from typing import Optional
 import logging
 from fandango.language.parser.FandangoLexer import FandangoLexer
 from fandango.language.server.semantic_tokens import (
@@ -42,7 +42,7 @@ class FileAssets:
 class FandangoLanguageServer(LanguageServer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.files: Dict[str, FileAssets] = {}
+        self.files: dict[str, FileAssets] = {}
 
     def get_text_document(self, document: lsp.VersionedTextDocumentIdentifier):
         return self.workspace.get_text_document(document.uri)

--- a/src/fandango/language/server/language_server.py
+++ b/src/fandango/language/server/language_server.py
@@ -1,7 +1,7 @@
 from antlr4 import InputStream, Token
 from pygls.server import LanguageServer
 import lsprotocol.types as lsp
-from typing import Dict, Optional,  
+from typing import Dict, Optional
 import logging
 from fandango.language.parser.FandangoLexer import FandangoLexer
 from fandango.language.server.semantic_tokens import (

--- a/src/fandango/language/server/semantic_tokens.py
+++ b/src/fandango/language/server/semantic_tokens.py
@@ -1,8 +1,6 @@
 # from https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokenTypes
 
 import enum
-from typing import List
-
 from antlr4 import Token
 
 
@@ -102,7 +100,7 @@ class SemanticTokenModifiers(enum.Enum):
         return [e.value for e in cls]
 
     @classmethod
-    def from_token(cls, token: Token) -> List["SemanticTokenModifiers"]:
+    def from_token(cls, token: Token) -> list["SemanticTokenModifiers"]:
         """Get the semantic token modifiers for a given token.
 
         :param token: The token to get the semantic token modifiers for

--- a/src/fandango/language/tree.py
+++ b/src/fandango/language/tree.py
@@ -1,7 +1,7 @@
 import copy
 from copy import deepcopy
 from io import BytesIO, StringIO
-from typing import Any, List, Optional, Set, Tuple, Union
+from typing import Any, Optional, Set, Tuple, Union
 
 from fandango import FandangoValueError
 from fandango.language.symbol import NonTerminal, Slice, Symbol, Terminal
@@ -15,10 +15,10 @@ class DerivationTree:
     def __init__(
         self,
         symbol: Symbol,
-        children: Optional[List["DerivationTree"]] = None,
+        children: Optional[list["DerivationTree"]] = None,
         *,
         parent: Optional["DerivationTree"] = None,
-        sources: list["DerivationTree"] = None,
+        sources: Optional[list["DerivationTree"]] = None,
         read_only: bool = False,
     ):
         """
@@ -105,7 +105,7 @@ class DerivationTree:
         for child in self._children:
             child.set_all_read_only(read_only)
 
-    def set_children(self, children: List["DerivationTree"]):
+    def set_children(self, children: list["DerivationTree"]):
         self._children = children
         self._update_size(1 + sum(child.size() for child in self._children))
         for child in self._children:
@@ -136,7 +136,7 @@ class DerivationTree:
             self._parent._update_size(self.parent.size() + new_val - self._size)
         self._size = new_val
 
-    def find_all_trees(self, symbol: NonTerminal) -> List["DerivationTree"]:
+    def find_all_trees(self, symbol: NonTerminal) -> list["DerivationTree"]:
         trees = sum(
             [
                 child.find_all_trees(symbol)
@@ -149,7 +149,7 @@ class DerivationTree:
             trees.append(self)
         return trees
 
-    def find_direct_trees(self, symbol: NonTerminal) -> List["DerivationTree"]:
+    def find_direct_trees(self, symbol: NonTerminal) -> list["DerivationTree"]:
         return [
             child
             for child in [*self._children, *self._sources]
@@ -182,7 +182,7 @@ class DerivationTree:
         return self.symbol, [child.__tree__() for child in self._children]
 
     @staticmethod
-    def from_tree(tree: Tuple[str, List[Tuple[str, List]]]) -> "DerivationTree":
+    def from_tree(tree: Tuple[str, list[Tuple[str, list]]]) -> "DerivationTree":
         symbol, children = tree
         if not isinstance(symbol, str):
             raise TypeError(f"{symbol} must be a string")
@@ -626,7 +626,7 @@ class DerivationTree:
 
     def find_all_nodes(
         self, symbol: NonTerminal, exclude_read_only=True
-    ) -> List["DerivationTree"]:
+    ) -> list["DerivationTree"]:
         """
         Find all nodes in the derivation tree with the given non-terminal symbol.
         """
@@ -638,7 +638,7 @@ class DerivationTree:
         return nodes
 
     @property
-    def children(self) -> Optional[List["DerivationTree"]]:
+    def children(self) -> Optional[list["DerivationTree"]]:
         """
         Return the children of the current node.
         """
@@ -944,5 +944,5 @@ class DerivationTree:
 
 
 class SliceTree(DerivationTree):
-    def __init__(self, children: List["DerivationTree"], read_only: bool = False):
+    def __init__(self, children: list["DerivationTree"], read_only: bool = False):
         super().__init__(Slice(), children, read_only=read_only)

--- a/src/fandango/language/tree.py
+++ b/src/fandango/language/tree.py
@@ -1,7 +1,7 @@
 import copy
 from copy import deepcopy
 from io import BytesIO, StringIO
-from typing import Any, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 from fandango import FandangoValueError
 from fandango.language.symbol import NonTerminal, Slice, Symbol, Terminal
@@ -182,7 +182,7 @@ class DerivationTree:
         return self.symbol, [child.__tree__() for child in self._children]
 
     @staticmethod
-    def from_tree(tree: Tuple[str, list[Tuple[str, list]]]) -> "DerivationTree":
+    def from_tree(tree: tuple[str, list[tuple[str, list]]]) -> "DerivationTree":
         symbol, children = tree
         if not isinstance(symbol, str):
             raise TypeError(f"{symbol} must be a string")
@@ -613,7 +613,7 @@ class DerivationTree:
 
         return new_tree
 
-    def get_non_terminal_symbols(self, exclude_read_only=True) -> Set[NonTerminal]:
+    def get_non_terminal_symbols(self, exclude_read_only=True) -> set[NonTerminal]:
         """
         Retrieve all non-terminal symbols present in the derivation tree.
         """

--- a/tests/test_havoc.py
+++ b/tests/test_havoc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env pytest
 
-from typing import Counter,  
+from typing import Counter
 import pytest
 
 from fandango.evolution import havoc

--- a/tests/test_havoc.py
+++ b/tests/test_havoc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env pytest
 
-from typing import Counter, List
+from typing import Counter,  
 import pytest
 
 from fandango.evolution import havoc
@@ -9,7 +9,7 @@ ITERS = 100000
 INPUT_SIZE = 100
 
 
-def adjacent_diff(input: bytearray) -> List[int]:
+def adjacent_diff(input: bytearray) -> list[int]:
     return [input[i] - input[i - 1] for i in range(1, len(input))]
 
 

--- a/tests/test_havoc.py
+++ b/tests/test_havoc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env pytest
 
-from typing import Counter
+from collections import Counter
 import pytest
 
 from fandango.evolution import havoc

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -52,7 +52,7 @@ class GeneticTest(unittest.TestCase):
             self.assertIsInstance(fitness, float)
             self.assertGreaterEqual(fitness, 0.0)
             self.assertLessEqual(fitness, 1.0)
-            self.assertIsInstance(failing_trees, List)
+            self.assertIsInstance(failing_trees, list)
             for failing_tree in failing_trees:
                 self.assertIsInstance(failing_tree, FailingTree)
             self.assertTrue(self.fandango.grammar.parse(str(individual)))
@@ -67,7 +67,7 @@ class GeneticTest(unittest.TestCase):
             self.assertIsInstance(fitness, float)
             self.assertGreaterEqual(fitness, 0.0)
             self.assertLessEqual(fitness, 1.0)
-            self.assertIsInstance(failing_trees, List)
+            self.assertIsInstance(failing_trees, list)
             for failing_tree in failing_trees:
                 self.assertIsInstance(failing_tree, FailingTree)
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -2,8 +2,6 @@
 
 import random
 import unittest
-from typing import List
-
 from fandango.constraints.fitness import FailingTree
 from fandango.evolution.algorithm import Fandango
 from fandango.language.parse import parse
@@ -194,7 +192,7 @@ class DeterminismTests(unittest.TestCase):
             desired_solutions=desired_solutions,
             random_seed=random_seed,
         )
-        solutions: List[DerivationTree] = fandango.evolve()
+        solutions: list[DerivationTree] = fandango.evolve()
         return [s.to_string() for s in solutions]
 
     def test_deterministic_solutions(self):

--- a/tests/test_softconstraint.py
+++ b/tests/test_softconstraint.py
@@ -4,8 +4,6 @@ import unittest
 import unittest
 import subprocess
 import shlex
-from typing import List
-
 from fandango.evolution.algorithm import Fandango
 from fandango.language.parse import parse
 from fandango.language.tree import DerivationTree
@@ -24,7 +22,7 @@ class TestSoft(unittest.TestCase):
             max_generations=max_generations,
             random_seed=random_seed,
         )
-        solutions: List[DerivationTree] = fandango.evolve()
+        solutions: list[DerivationTree] = fandango.evolve()
         return [s.to_string() for s in solutions]
 
     def run_command(self, command):

--- a/utils/bt2fan/bt2fan.py
+++ b/utils/bt2fan/bt2fan.py
@@ -378,7 +378,7 @@ class BT2FandangoVisitor(c_ast.NodeVisitor):
             var = binary_op.right.name
 
         # Identify the function call
-        funccall: c_ast.FuncCall = None
+        funccall: Optional[c_ast.FuncCall] = None
         if isinstance(left, c_ast.FuncCall):
             funccall = left
         elif isinstance(right, c_ast.FuncCall):


### PR DESCRIPTION
I'm trying to understand the structure of the main algorithm, and I started refactoring certain things as I understood them better, removed (almost) identical code, extracted functions, moved code around so it better fits, etc.

Also: The following types are deprecated (see [Python docs](https://docs.python.org/3/library/typing.html#typing.Dict)) in favour of their lowercase counterparts, so I unified their usage across the code base:
- `List` -> `list`
- `Dict` -> `dict`
- `Set` -> `set`
- `Tuple` -> `tuple`
- etc.