### PR TITLE
Move python dependencies from Makefile to pyproject.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,8 +270,7 @@ credit:
 # We separate _installing_ from _running_ tests
 # so we can run 'make tests' quickly (see above)
 # without having to reinstall things
-install-test install-tests:
-	$(PIP) install pytest mypy pytest-xdist
+install-test install-tests: 
 	$(PIP) install -e ".[test]"
 
 uninstall:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,6 @@ classifiers = [
     "Topic :: Software Development :: Testing"
 ]
 
-[project.urls]
-homepage = "https://fandango-fuzzer.github.io/"
-repository = "https://github.com/fandango-fuzzer/fandango/"
-"Bug Tracker" = "https://github.com/fandango-fuzzer/fandango/issues"
-
-[project.scripts]
-fandango = "fandango.cli:main"
-
 dependencies = [
     "ansi_styles>=0.2.2",
     "antlr4-python3-runtime>=4.13",
@@ -76,6 +68,14 @@ test = [
     "sphinxcontrib-mermaid>=1.0.0",
     "tccbox",
 ]
+
+[project.urls]
+homepage = "https://fandango-fuzzer.github.io/"
+repository = "https://github.com/fandango-fuzzer/fandango/"
+"Bug Tracker" = "https://github.com/fandango-fuzzer/fandango/issues"
+
+[project.scripts]
+fandango = "fandango.cli:main"
 
 [tool.black]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,23 +26,6 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Testing"
 ]
-dependencies = [
-    "pytest>=7.2.2",
-    "antlr4-python3-runtime>=4.13",
-    "deprecation>=2.1.0",
-    "ansi_styles>=0.2.2",
-    "cachedir_tag>=0.0.3",
-    "xdg-base-dirs>=6.0.2",
-    "dill>=0.3.7",
-    "thefuzz>=0.22",
-    "py010parser>=0.1.18",
-    "exrex>=0.12.0",
-    "gnureadline>=8.2.13 ; platform_system != 'Windows' and implementation_name != 'pypy'",
-    "pyreadline3>=3.5.4; platform_system == 'Windows'",
-    "tdigest>=0.5.2.2",
-    "pygls>=1.0.0",
-    "lxml>=5.3.2",
-]
 
 [project.urls]
 homepage = "https://fandango-fuzzer.github.io/"
@@ -52,26 +35,46 @@ repository = "https://github.com/fandango-fuzzer/fandango/"
 [project.scripts]
 fandango = "fandango.cli:main"
 
+dependencies = [
+    "ansi_styles>=0.2.2",
+    "antlr4-python3-runtime>=4.13",
+    "cachedir_tag>=0.0.3",
+    "deprecation>=2.1.0",
+    "dill>=0.3.7",
+    "exrex>=0.12.0",
+    "gnureadline>=8.2.13 ; platform_system != 'Windows' and implementation_name != 'pypy'",
+    "lxml>=5.3.2",
+    "py010parser>=0.1.18",
+    "pygls>=1.0.0",
+    "pyreadline3>=3.5.4; platform_system == 'Windows'",
+    "tdigest>=0.5.2.2",
+    "thefuzz>=0.22",
+    "xdg-base-dirs>=6.0.2",
+]
+
 [project.optional-dependencies]
 test = [
+    "cryptography>=44.0.1",
+    "deap>=1.4.1",
+    "docutils>=0.20.1",  # Jupyter-book needs docutils<=0.20
+    "Faker>=30.4.0",
+    "jupyter-book>=1.0.4",
+    "matplotlib>=3.9.2",
+    "mypy>=1.16.0",
+    "numpy>=2.2.1",  # Avoid conflict with pandas
+    "ordered-set>=4.0.2",
+    "pagelabels>=1.2.1",
+    "parameterized>=0.8.1",
     "pytest-cov>=4.1.0",
     "pytest-html>=3.2.0",
     "pytest-rerunfailures>=11.1.2",
-    "parameterized>=0.8.1",
-    "Faker>=30.4.0",
-    "docutils>=0.20.1",  # Jupyter-book needs docutils<=0.20
-    "tccbox",
+    "pytest-xdist>=3.7.0",
+    "pytest>=8.3.5",
     "python-dateutil>=2.9.0.post0",
-    "deap>=1.4.1",
     "scipy>=1.14.1",
-    "numpy>=2.2.1",  # Avoid conflict with pandas
-    "matplotlib>=3.9.2",
-    "ordered-set>=4.0.2",
-    "cryptography>=44.0.1",
     "speedy-antlr-tool>=1.4.3",
-    "jupyter-book>=1.0.4",
     "sphinxcontrib-mermaid>=1.0.0",
-    "pagelabels>=1.2.1",
+    "tccbox",
 ]
 
 [tool.black]


### PR DESCRIPTION
This unifies where dependencies are stored. I have also sorted the dependencies alphabetically, to make them more readable.