### PR TITLE
Fix language server

### DIFF
--- a/src/fandango/language/server/semantic_tokens.py
+++ b/src/fandango/language/server/semantic_tokens.py
@@ -50,7 +50,7 @@ class SemanticTokenTypes(enum.Enum):
         :return: The semantic token type
         """
         match token.type:
-            case "NONTERMINAL":
+            case "NAME":
                 return SemanticTokenTypes.variable
             case "STRING_LITERAL" | "BYTES_LITERAL":
                 return SemanticTokenTypes.string


### PR DESCRIPTION
@andreas-zeller do I have access to the C++ lexer (and just the lexer) somewhere? The python lexer takes ~0.5s on the CSV spec, which is noticable, e.g. when you type `<` and have to wait for a re-lexing of the document before the autocomplete kicks in. Yes, I could also do caching, but I think the functionality should be around, so why not use it?

_Parsing_ with the C++ parser takes ~0.1s. I can't use the parser, because it will fail if the spec is not valid at all times (which  is not the case e.g. when you're in the middle of writing a nonterminal).