### PR TITLE
Support more python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,10 @@ license = "EUPL-1.2"
 requires-python = ">=3.10,<4.0"
 classifiers = [
     "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Testing"
@@ -67,7 +70,7 @@ evaluation = [
 ]
 
 book = [
-    "fandango-fuzzer[development]", # need black and faker
+    "fandango-fuzzer[development]", # need black and faker
     "aiosmtpd>=1.4.6",  # example server for protocol testing
     "docutils>=0.20.1",  # Jupyter-book needs docutils<=0.20
     "ghp-import>=2.1.0",


### PR DESCRIPTION
Binaries are only built/published for the supported python versions. If a user has a different version of python installed, they will not get the binary but the C++ parser will instead be built from source.