### PR TITLE
Properly introduce beartype

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run tests (dev or non-Ubuntu)
         if: github.ref != 'refs/heads/main' || matrix.os != 'ubuntu-latest'
         run: |
-          make tests
+          pytest
 
       - name: Install system dependencies for coverage (main + Ubuntu only)
         if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ test: $(PYTHON_SOURCES) $(TEST_SOURCES)
 
 # As above, but run tests in parallel
 tests $(TEST_MARKER): $(PYTHON_SOURCES) $(TEST_SOURCES)
-	$(PYTEST) -n auto --timeout 180
+	$(PYTEST)
 	echo 'Success' > $(TEST_MARKER)
 
 COVERAGE = coverage.xml

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,13 @@
-def pytest_configure(config):
-    from fandango.beartype import activate_beartype
+import os
+from fandango.beartype import activate_beartype
 
+def pytest_configure(config):
+    os.environ["FANDANGO_RUN_BEARTYPE"] = "1"
     activate_beartype()
+
+def pytest_collection_modifyitems(items):
+    # ensure long-running tests are run first to balance loading across cores
+    # so we have to wait less for a single long test to finish running because it was scheduled last
+    order = ["cli", "softconstraint", "optimizer", "fan_parsers"]
+    priority = [f"tests/{test}.py" for test in order]
+    items.sort(key=lambda x: priority.index(x.location[0]) if x.location[0] in priority else len(priority))

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,4 @@
+def pytest_configure(config):
+    from fandango.beartype import activate_beartype
+
+    activate_beartype()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,3 +110,6 @@ exclude = [
     'src/fandango/converters/antlr/ANTLRv4[^.]*\.py$',
     'src/fandango/converters/antlr/LexerAdaptor[^.]*\.py$',
 ]
+
+[tool.pytest.ini_options]
+addopts = "-n auto --timeout 180"

--- a/src/fandango/__init__.py
+++ b/src/fandango/__init__.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
 
+# needs to be before any other imports
+import os
+from fandango.beartype import activate_beartype
+
+if os.environ.get("FANDANGO_RUN_BEARTYPE", False):
+    activate_beartype()
+
 import importlib.metadata
 import logging
-import os
 import sys
 
 from fandango.api import Fandango
@@ -14,7 +20,6 @@ from fandango.errors import (
 )
 import fandango.language.tree
 import fandango.language.parse
-from fandango.logger import LOGGER
 
 __all__ = [
     "FandangoError",
@@ -26,21 +31,6 @@ __all__ = [
     "version",
     "homepage",
 ]
-
-if "pytest" in sys.modules or os.environ.get("FANDANGO_RUN_BEARTYPE", False):
-    from beartype.claw import beartype_this_package  # type: ignore [import-not-found]
-    from beartype import BeartypeConf  # type: ignore [import-not-found]
-
-    LOGGER.info("Running with dynamic type checking via beartype")
-    beartype_this_package(
-        conf=BeartypeConf(
-            claw_skip_package_names=(
-                "fandango.converters.antlr.ANTLRv4Parser",  # auto-generated
-                "fandango.converters.antlr.ANTLRv4Lexer",  # auto-generated
-            )
-        )
-    )
-
 
 DISTRIBUTION_NAME = "fandango-fuzzer"
 

--- a/src/fandango/__init__.py
+++ b/src/fandango/__init__.py
@@ -2,6 +2,7 @@
 
 import importlib.metadata
 import logging
+import os
 import sys
 
 from fandango.api import Fandango
@@ -13,6 +14,7 @@ from fandango.errors import (
 )
 import fandango.language.tree
 import fandango.language.parse
+from fandango.logger import LOGGER
 
 __all__ = [
     "FandangoError",
@@ -25,11 +27,19 @@ __all__ = [
     "homepage",
 ]
 
-if "pytest" in sys.modules:
+if "pytest" in sys.modules or os.environ.get("FANDANGO_RUN_BEARTYPE", False):
     from beartype.claw import beartype_this_package  # type: ignore [import-not-found]
     from beartype import BeartypeConf  # type: ignore [import-not-found]
 
-    beartype_this_package(conf=BeartypeConf(claw_skip_package_names=("fandango",)))
+    LOGGER.info("Running with dynamic type checking via beartype")
+    beartype_this_package(
+        conf=BeartypeConf(
+            claw_skip_package_names=(
+                "fandango.converters.antlr.ANTLRv4Parser",  # auto-generated
+                "fandango.converters.antlr.ANTLRv4Lexer",  # auto-generated
+            )
+        )
+    )
 
 
 DISTRIBUTION_NAME = "fandango-fuzzer"

--- a/src/fandango/api.py
+++ b/src/fandango/api.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Generator, Iterable
 import itertools
 import logging
 import time
-from typing import IO, Callable, Generator, Iterable, Optional
+from typing import IO, Optional
 from fandango.constraints.base import Constraint, SoftValue
 from fandango.language.grammar import FuzzingMode, Grammar
 from fandango.language.parse import parse

--- a/src/fandango/beartype.py
+++ b/src/fandango/beartype.py
@@ -1,0 +1,18 @@
+def activate_beartype() -> None:
+    from beartype.claw import beartype_this_package  # type: ignore [import-not-found]
+    from beartype import BeartypeConf  # type: ignore [import-not-found]
+
+    skip_packages = (
+        "fandango.converters.antlr.ANTLRv4Parser",  # auto-generated
+        "fandango.converters.antlr.ANTLRv4Lexer",  # auto-generated
+        "fandango.language.grammar",  # broken
+        "fandango.language.symbol",  # broken
+        "fandango.language.parser",  # broken
+        "fandango.language.search",  # broken, at least test_item_search and test_searches call ItemSearch with non-lists
+        "fandango.constraints.fitness",  # ValueFitness sometimes receives a list of ints in the constructor
+        "fandango.api",  # at least `parse` is broken
+        "fandango.io.packetforecaster",  # broken
+        "fandango.language.tree",  # broken, I think it's at least cyclical imports with grammar
+    )
+
+    beartype_this_package(conf=BeartypeConf(claw_skip_package_names=skip_packages))

--- a/src/fandango/language/grammar.py
+++ b/src/fandango/language/grammar.py
@@ -6,8 +6,8 @@ import time
 import typing
 from collections import defaultdict
 from copy import deepcopy
-from typing import Any, Iterator, Optional, Union
-from collections.abc import Generator
+from typing import Any, Optional, Union
+from collections.abc import Generator, Iterator
 
 import exrex
 from thefuzz import process as thefuzz_process
@@ -63,7 +63,7 @@ class Node(abc.ABC):
 
     def fuzz(
         self,
-        parent: "DerivationTree",
+        parent: DerivationTree,
         grammar: "Grammar",
         max_nodes: int = 100,
         in_message: bool = False,
@@ -115,7 +115,7 @@ class Alternative(Node):
 
     def fuzz(
         self,
-        parent: "DerivationTree",
+        parent: DerivationTree,
         grammar: "Grammar",
         max_nodes: int = 100,
         in_message: bool = False,
@@ -171,7 +171,7 @@ class Concatenation(Node):
 
     def fuzz(
         self,
-        parent: "DerivationTree",
+        parent: DerivationTree,
         grammar: "Grammar",
         max_nodes: int = 100,
         in_message: bool = False,
@@ -328,7 +328,7 @@ class Repetition(Node):
 
     def fuzz(
         self,
-        parent: "DerivationTree",
+        parent: DerivationTree,
         grammar: "Grammar",
         max_nodes: int = 100,
         in_message: bool = False,
@@ -454,7 +454,7 @@ class NonTerminalNode(Node):
 
     def fuzz(
         self,
-        parent: "DerivationTree",
+        parent: DerivationTree,
         grammar: "Grammar",
         max_nodes: int = 100,
         in_message: bool = False,
@@ -549,7 +549,7 @@ class TerminalNode(Node):
 
     def fuzz(
         self,
-        parent: "DerivationTree",
+        parent: DerivationTree,
         grammar: "Grammar",
         max_nodes: int = 100,
         in_message: bool = False,
@@ -616,7 +616,7 @@ class CharSet(Node):
 
     def fuzz(
         self,
-        parent: "DerivationTree",
+        parent: DerivationTree,
         grammar: "Grammar",
         max_nodes: int = 100,
         in_message: bool = False,
@@ -1108,9 +1108,9 @@ class Grammar(NodeVisitor):
         def __init__(
             self,
             symbol: Symbol,
-            children: Optional[list["DerivationTree"]] = None,
+            children: Optional[list[DerivationTree]] = None,
             *,
-            parent: Optional["DerivationTree"] = None,
+            parent: Optional[DerivationTree] = None,
             sender: Optional[str] = None,
             recipient=None,
             read_only: bool = False,
@@ -1125,7 +1125,7 @@ class Grammar(NodeVisitor):
                 read_only=read_only,
             )
 
-        def set_children(self, children: list["DerivationTree"]):
+        def set_children(self, children: list[DerivationTree]):
             self._children = children
             self.invalidate_hash()
 
@@ -1160,7 +1160,7 @@ class Grammar(NodeVisitor):
             ] = {}
             self._incomplete: set[DerivationTree] = set()
             self._max_position = -1
-            self.elapsed_time: float = 0
+            self.elapsed_time: float = 0.0
             self._process()
 
         def _process(self):
@@ -1981,7 +1981,7 @@ class Grammar(NodeVisitor):
             print("Cycle exists")
         return topological_order[::-1]
 
-    def is_use_generator(self, tree: "DerivationTree"):
+    def is_use_generator(self, tree: DerivationTree):
         symbol = tree.symbol
         if not isinstance(symbol, NonTerminal):
             return False
@@ -1995,7 +1995,7 @@ class Grammar(NodeVisitor):
         intersection = path.intersection(set(generator_dependencies))
         return len(intersection) == 0
 
-    def derive_sources(self, tree: "DerivationTree"):
+    def derive_sources(self, tree: DerivationTree):
         gen_symbol = tree.symbol
         if not isinstance(gen_symbol, NonTerminal):
             raise FandangoValueError(f"Tree {tree.symbol} is not a nonterminal")
@@ -2033,15 +2033,15 @@ class Grammar(NodeVisitor):
         args.pop(0)
         return args
 
-    def derive_generator_output(self, tree: "DerivationTree"):
+    def derive_generator_output(self, tree: DerivationTree):
         generated = self.generate(tree.nonterminal, tree.sources)
         return generated.children
 
-    def populate_sources(self, tree: "DerivationTree"):
+    def populate_sources(self, tree: DerivationTree):
         self._rec_remove_sources(tree)
         self._populate_sources(tree)
 
-    def _populate_sources(self, tree: "DerivationTree"):
+    def _populate_sources(self, tree: DerivationTree):
         if self.is_use_generator(tree):
             tree.sources = self.derive_sources(tree)
             for child in tree.children:
@@ -2050,7 +2050,7 @@ class Grammar(NodeVisitor):
         for child in tree.children:
             self._populate_sources(child)
 
-    def _rec_remove_sources(self, tree: "DerivationTree"):
+    def _rec_remove_sources(self, tree: DerivationTree):
         tree.sources = []
         for child in tree.children:
             self._rec_remove_sources(child)

--- a/src/fandango/language/parser/FandangoLexerBase.py
+++ b/src/fandango/language/parser/FandangoLexerBase.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
 import re
 import sys
-from typing import TextIO, Optional
+from typing import TYPE_CHECKING, TextIO, Optional
 
 # noinspection PyUnresolvedReferences
 from fandango.language.parser.FandangoParser import FandangoParser
@@ -9,6 +10,9 @@ from antlr4.Token import CommonToken
 
 # noinspection PyUnresolvedReferences
 from fandango.language.parser.FandangoParser import FandangoParser
+
+if TYPE_CHECKING:
+    import fandango
 
 # Current lexer instance, set by the generated lexer code
 lexer: Optional["FandangoLexerBase"] = None

--- a/src/fandango/language/search.py
+++ b/src/fandango/language/search.py
@@ -4,7 +4,7 @@ search criteria.
 """
 
 import abc
-from typing import List, Optional, Dict, Tuple, Any
+from typing import Optional, Any
 
 from fandango.language.symbol import NonTerminal
 from fandango.language.tree import DerivationTree
@@ -18,10 +18,10 @@ class Container(abc.ABC):
     """
 
     @abc.abstractmethod
-    def get_trees(self) -> List[DerivationTree]:
+    def get_trees(self) -> list[DerivationTree]:
         """
         Get the list of derivation trees in the container.
-        :return List[DerivationTree]: The list of derivation trees.
+        :return list[DerivationTree]: The list of derivation trees.
         """
         pass
 
@@ -46,10 +46,10 @@ class Tree(Container):
         """
         self.tree = tree
 
-    def get_trees(self) -> List[DerivationTree]:
+    def get_trees(self) -> list[DerivationTree]:
         """
         Get the list of derivation trees in the container.
-        :return List[DerivationTree]: The list of derivation trees.
+        :return list[DerivationTree]: The list of derivation trees.
         """
         return [self.tree]
 
@@ -72,24 +72,24 @@ class TreeList(Container):
     Container that holds a list of derivation trees.
     """
 
-    def __init__(self, trees: List[DerivationTree]):
+    def __init__(self, trees: list[DerivationTree]):
         """
         Initialize the TreeList container with the given derivation trees.
-        :param List[DerivationTree] trees: The list of derivation trees.
+        :param list[DerivationTree] trees: The list of derivation trees.
         """
         self.trees = trees
 
-    def get_trees(self) -> List[DerivationTree]:
+    def get_trees(self) -> list[DerivationTree]:
         """
         Get the list of derivation trees in the container.
-        :return List[DerivationTree]: The list of derivation trees.
+        :return list[DerivationTree]: The list of derivation trees.
         """
         return self.trees
 
     def evaluate(self):
         """
         Evaluate the container. The evaluation of a TreeList container is the list of trees itself.
-        :return List[DerivationTree]: The list of derivation trees.
+        :return list[DerivationTree]: The list of derivation trees.
         """
         return self.trees
 
@@ -99,17 +99,17 @@ class Length(Container):
     Container that holds a list of derivation trees and evaluates to the length of the list.
     """
 
-    def __init__(self, trees: List[DerivationTree]):
+    def __init__(self, trees: list[DerivationTree]):
         """
         Initialize the Tree container with the given derivation trees.
-        :param List[DerivationTree] trees: The list of derivation trees.
+        :param list[DerivationTree] trees: The list of derivation trees.
         """
         self.trees = trees
 
-    def get_trees(self) -> List[DerivationTree]:
+    def get_trees(self) -> list[DerivationTree]:
         """
         Get the list of derivation trees in the container.
-        :return List[DerivationTree]: The list of derivation trees.
+        :return list[DerivationTree]: The list of derivation trees.
         """
         return self.trees
 
@@ -141,13 +141,13 @@ class NonTerminalSearch(abc.ABC):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         """
         Find all the non-terminals in the derivation tree that match the search criteria.
         :param DerivationTree tree: The derivation tree.
-        :param Optional[Dict[NonTerminal, List[DerivationTree]]] scope: The scope of non-terminals matching to trees.
+        :param Optional[Dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
         :param Optional[list[DerivationTree]] population: The population of derivation trees to search in.
-        :return List[Container]: The list of containers that hold the matching derivation trees.
+        :return list[Container]: The list of containers that hold the matching derivation trees.
         """
 
     def quantify(
@@ -155,11 +155,11 @@ class NonTerminalSearch(abc.ABC):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         """
         Quantify the number of non-terminals in the derivation tree that match the search criteria.
         :param DerivationTree tree: The derivation tree.
-        :param Optional[Dict[NonTerminal, List[DerivationTree]]] scope: The scope of non-terminals matching to trees.
+        :param Optional[Dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
         :param Optional[list[DerivationTree]] population: The population of derivation trees to search in.
         :return int: The number of matching non-terminals.
         """
@@ -171,27 +171,27 @@ class NonTerminalSearch(abc.ABC):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         """
         Find the direct-child non-terminals in the derivation tree that match the search criteria.
         :param DerivationTree tree: The derivation tree.
-        :param Optional[Dict[NonTerminal, List[DerivationTree]]] scope: The scope of non-terminals matching to trees.
+        :param Optional[Dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
         :param Optional[list[DerivationTree]] population: The population of derivation trees to search in.
-        :return List[Container]: The list of containers that hold the matching derivation trees.
+        :return list[Container]: The list of containers that hold the matching derivation trees.
         """
 
     def find_all(
         self,
-        trees: List[DerivationTree],
+        trees: list[DerivationTree],
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         """
         Find all the non-terminals in the list of derivation trees that match the search criteria.
-        :param List[DerivationTree] trees: The list of derivation trees.
-        :param Optional[Dict[NonTerminal, List[DerivationTree]]] scope: The scope of non-terminals matching to trees.
+        :param list[DerivationTree] trees: The list of derivation trees.
+        :param Optional[Dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
         :param Optional[list[DerivationTree]] population: The population of derivation trees to search in.
-        :return List[List[Container]]: The list of lists of containers that hold the matching derivation trees.
+        :return list[list[Container]]: The list of lists of containers that hold the matching derivation trees.
         """
         targets = []
         for tree in trees:
@@ -206,10 +206,10 @@ class NonTerminalSearch(abc.ABC):
         return self.__repr__()
 
     @abc.abstractmethod
-    def get_access_points(self) -> List[NonTerminal]:
+    def get_access_points(self) -> list[NonTerminal]:
         """
         Get the access points of the non-terminal search, i.e., the non-terminal that are considered in this search.
-        :return List[NonTerminal]: The list of access points.
+        :return list[NonTerminal]: The list of access points.
         """
 
 
@@ -230,7 +230,7 @@ class LengthSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         return [
             Length(
                 sum(
@@ -250,7 +250,7 @@ class LengthSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         return [
             Length(
                 sum(
@@ -289,7 +289,7 @@ class RuleSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         if scope and self.symbol in scope:
             return [Tree(scope[self.symbol])]
         else:
@@ -300,7 +300,7 @@ class RuleSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         if scope and self.symbol in scope:
             return [Tree(scope[self.symbol])]
         else:
@@ -333,7 +333,7 @@ class AttributeSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         bases = self.base.find(tree, scope=scope, population=population)
         targets = []
         for base in bases:
@@ -348,7 +348,7 @@ class AttributeSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         bases = self.base.find_direct(tree, scope=scope, population=population)
         targets = []
         for base in bases:
@@ -385,7 +385,7 @@ class DescendantAttributeSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         bases = self.base.find(tree, scope=scope, population=population)
         targets = []
         for base in bases:
@@ -400,7 +400,7 @@ class DescendantAttributeSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         bases = self.base.find_direct(tree, scope=scope, population=population)
         targets = []
         for base in bases:
@@ -425,16 +425,16 @@ class ItemSearch(NonTerminalSearch):
     Non-terminal search that finds the non-terminals that get the items from the base non-terminal.
     """
 
-    def __init__(self, base: NonTerminalSearch, slices: list[Tuple[Any] | slice | int]):
+    def __init__(self, base: NonTerminalSearch, slices: list[tuple[Any] | slice | int]):
         """
         Initialize the ItemSearch with the given base and slices.
         :param NonTerminalSearch base: The base non-terminal
-        :param Tuple[Any] slices: The slices to get the items from the base non-terminal.
+        :param tuple[Any] slices: The slices to get the items from the base non-terminal.
         """
         self.base = base
         self.slices = slices
 
-    def _find(self, bases: List[Container]):
+    def _find(self, bases: list[Container]):
         return list(
             map(
                 Tree,
@@ -451,7 +451,7 @@ class ItemSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         return self._find(self.base.find(tree, scope=scope, population=population))
 
     def find_direct(
@@ -459,7 +459,7 @@ class ItemSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         return self._find(
             self.base.find_direct(tree, scope=scope, population=population)
         )
@@ -510,20 +510,20 @@ class SelectiveSearch(NonTerminalSearch):
     def __init__(
         self,
         base: NonTerminalSearch,
-        symbols: List[Tuple[NonTerminal, bool]],
-        slices: Optional[List[Optional[Any]]] = None,
+        symbols: list[tuple[NonTerminal, bool]],
+        slices: Optional[list[Optional[Any]]] = None,
     ):
         """
         Initialize the SelectiveSearch with the given base, symbols, and slices.
         :param NonTerminalSearch base: The base non-terminal search.
-        :param List[Tuple[NonTerminal, bool]] symbols: The list of symbols and whether to find direct or all trees.
-        :param List[Optional[Any]] slices: The list of slices to get the items from the symbols.
+        :param list[tuple[NonTerminal, bool]] symbols: The list of symbols and whether to find direct or all trees.
+        :param list[Optional[Any]] slices: The list of slices to get the items from the symbols.
         """
         self.base = base
         self.symbols = symbols
         self.slices = slices or [None] * len(symbols)
 
-    def _find(self, bases: List[Container]):
+    def _find(self, bases: list[Container]):
         result = []
         for symbol, is_direct, items in zip(*zip(*self.symbols), self.slices):
             if is_direct:
@@ -548,7 +548,7 @@ class SelectiveSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         ret = self._find(self.base.find(tree, scope=scope, population=population))
         return ret
 
@@ -557,7 +557,7 @@ class SelectiveSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         ret = self._find(self.base.find_direct(tree, scope=scope, population=None))
         return ret
 
@@ -603,7 +603,7 @@ class StarSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[DerivationTree]:
+    ) -> list[DerivationTree]:
         return sum(
             [
                 r.get_trees()
@@ -617,7 +617,7 @@ class StarSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         return [TreeList(self._find(tree, scope=scope, population=population))]
 
     def quantify(
@@ -625,11 +625,11 @@ class StarSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         """
         Quantify the number of non-terminals in the derivation tree that match the star search criteria.
         :param DerivationTree tree: The derivation tree.
-        :param Optional[Dict[NonTerminal, List[DerivationTree]]] scope: The scope of non-terminals matching to trees.
+        :param Optional[Dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
         :param Optional[list[DerivationTree]] population: The population of derivation trees to search in.
         :return int: The number of matching non-terminals.
         """
@@ -642,7 +642,7 @@ class StarSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         trees = sum(
             [
                 r.get_trees()
@@ -655,7 +655,7 @@ class StarSearch(NonTerminalSearch):
     def __repr__(self):
         return f"*{repr(self.base)}"
 
-    def get_access_points(self) -> List[NonTerminal]:
+    def get_access_points(self) -> list[NonTerminal]:
         return self.base.get_access_points()
 
 
@@ -677,7 +677,7 @@ class PopulationSearch(NonTerminalSearch):
         self,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[DerivationTree]:
+    ) -> list[DerivationTree]:
         if population is None:
             raise ValueError("Population is required for PopulationSearch")
         return sum(
@@ -695,7 +695,7 @@ class PopulationSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         return [TreeList(self._find(scope=scope, population=population))]
 
     def quantify(
@@ -703,11 +703,11 @@ class PopulationSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         """
         Quantify the number of non-terminals in the derivation tree that match the star search criteria.
         :param DerivationTree tree: The derivation tree.
-        :param Optional[Dict[NonTerminal, List[DerivationTree]]] scope: The scope of non-terminals matching to trees.
+        :param Optional[Dict[NonTerminal, list[DerivationTree]]] scope: The scope of non-terminals matching to trees.
         :param Optional[list[DerivationTree]] population: The population of derivation trees to search in.
         :return int: The number of matching non-terminals.
         """
@@ -718,7 +718,7 @@ class PopulationSearch(NonTerminalSearch):
         tree: DerivationTree,
         scope: Optional[dict[NonTerminal, DerivationTree]] = None,
         population: Optional[list[DerivationTree]] = None,
-    ) -> List[Container]:
+    ) -> list[Container]:
         if population is None:
             raise ValueError("Population is required for PopulationSearch")
         trees = sum(
@@ -735,5 +735,5 @@ class PopulationSearch(NonTerminalSearch):
     def __repr__(self):
         return f"**{repr(self.base)}"
 
-    def get_access_points(self) -> List[NonTerminal]:
+    def get_access_points(self) -> list[NonTerminal]:
         return self.base.get_access_points()

--- a/src/fandango/language/tree.py
+++ b/src/fandango/language/tree.py
@@ -87,10 +87,10 @@ class DerivationTree:
             raise TypeError(f"Expected Symbol, got {type(symbol)}")
 
         self.hash_cache: Optional[int] = None
-        self._parent: Optional["DerivationTree"] = parent
+        self._parent = parent
         self._sender = sender
         self._recipient = recipient
-        self._symbol: Symbol = symbol
+        self._symbol = symbol
         self._children: list["DerivationTree"] = []
         self._sources: list["DerivationTree"] = []
         if sources is not None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,6 +8,8 @@ RESOURCES_ROOT = TEST_ROOT / "resources"
 PROJECT_ROOT = TEST_ROOT.parent
 DOCS_ROOT = PROJECT_ROOT / "docs"
 
+IS_BEARTYPE_ACTIVE = os.environ.get("FANDANGO_RUN_BEARTYPE", False)
+
 
 def run_command(command_list, input=None):
     """Run a command and return normalized output with consistent line endings.
@@ -25,6 +27,9 @@ def run_command(command_list, input=None):
     if sys.platform.startswith("win"):
         env["PYTHONIOENCODING"] = "utf-8"
         env["PYTHONUTF8"] = "1"
+
+    if IS_BEARTYPE_ACTIVE:
+        env["FANDANGO_RUN_BEARTYPE"] = "1"
 
     proc = subprocess.Popen(
         command_list,


### PR DESCRIPTION
This should also fix the necessity for `beartype` to be a non-dev/-test dependency. I'll still leave it as a non-optional dependency, since the usage of `beartype` just depends on an environment variable. In the current unfixed state, if fandango is invoked in the unittests of a downstream project, `beartype` is run on fandango, which slows it down.

On the other hand: There's an argument to be made that this forces downstream projects to adhere to the type declarations and thus a feature and not a bug. Re-enabling it should be easy though, should we decide to want this.