### PR TITLE
fix: implement __str__ method for Symbol subclasses

### DIFF
--- a/src/fandango/language/symbols/non_terminal.py
+++ b/src/fandango/language/symbols/non_terminal.py
@@ -15,5 +15,8 @@ class NonTerminal(Symbol):
     def __hash__(self) -> int:
         return hash((self._value, self._type))
 
+    def __str__(self) -> str:
+        return self.name()
+
     def format_as_spec(self) -> str:
         return self.name()

--- a/src/fandango/language/symbols/terminal.py
+++ b/src/fandango/language/symbols/terminal.py
@@ -139,6 +139,9 @@ class Terminal(Symbol):
     def __hash__(self) -> int:
         return hash((self._value, self._type))
 
+    def __str__(self) -> str:
+        return self.format_as_spec()
+
     def __repr__(self) -> str:
         return "Terminal(" + self.format_as_spec() + ")"
 


### PR DESCRIPTION
- Add __str__ method to NonTerminal class
- Add __str__ method to Terminal class
- Fix NotImplementedError when symbols are used in f-strings
- Resolves error in message_nesting_detector error messages

Previously, both NonTerminal and Terminal inherited the abstract __str__ method from Symbol that raised NotImplementedError. This caused crashes when trying to format error messages that included symbols (e.g., in MessageNestingDetector.fail_on_nested_packet).

Now both classes properly implement __str__ by delegating to their respective formatting methods (name() and format_as_spec()).