### PR TITLE
Update __init__.py

### DIFF
--- a/src/fandango/io/__init__.py
+++ b/src/fandango/io/__init__.py
@@ -112,7 +112,7 @@ class FandangoParty(ABC):
         """
         Called when a message has been received by this party.
         :param sender: The sender of the message.
-        :param message: The sender of the message.
+        :param message: The content of the message.
         """
         if sender is None:
             parties = list(


### PR DESCRIPTION
Corrects the parameter description for 'message' in FandangoParty.on_message, clarifying that it refers to the content of the message rather than the sender.