### PR TITLE
Use auto for versioning-strategy for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
     directory: /
     schedule:
       interval: daily
-    versioning-strategy: widen
+    versioning-strategy: auto


### PR DESCRIPTION
`widen` is unsupported when `package-ecosystem` is set to `pip` so I set it to the default and see how it works.

> The property '#/updates/0/versioning-strategy' value "widen" did not match one of the following values: lockfile-only, auto, increase, increase-if-necessary

https://github.com/fandango-fuzzer/fandango/network/updates

Related: #732 