### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,12 @@ updates:
     directory: /
     versioning-strategy: auto
     multi-ecosystem-group: python
+    patterns:
+      - "*"
     
   - package-ecosystem: uv
     directory: /
     versioning-strategy: auto
     multi-ecosystem-group: python
+    patterns:
+      - "*"


### PR DESCRIPTION
Unfortunately there is currently no way to validate dependabot config before merging :(

https://github.com/dependabot/dependabot-core/issues/4605

Wait... the check shows up here, but why it didn't in #736?