### PR TITLE
Remove pip from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,9 @@
 version: 2
-
-multi-ecosystem-groups:
-  python:
-    schedule:
-      interval: daily
-
 updates:
-  - package-ecosystem: pip
-    directory: /
-    versioning-strategy: auto
-    multi-ecosystem-group: python
-    patterns:
-      - "*"
-    
   - package-ecosystem: uv
     directory: /
     versioning-strategy: auto
-    multi-ecosystem-group: python
+    schedule:
+      interval: daily
     patterns:
       - "*"


### PR DESCRIPTION
The `uv` part already handles `pyproject.toml`.

Solely updating `pyproject.toml` with dependabot can cause CI errors like in #752 as it obsoletes `uv.lock`.