### PR TITLE
Group patch updates for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,9 @@ updates:
     versioning-strategy: auto
     schedule:
       interval: daily
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
     patterns:
       - "*"


### PR DESCRIPTION
After discussion with @riesentoaster, we decided to have @dependabot group patch updates in a single PR, and have independent PRs for major/minor updates.