### PR TITLE
Banner for 1.1.0rc1

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -46,6 +46,7 @@ parse:
 html:
   use_issues_button: true
   use_repository_button: true
+  announcement: "<a href=\"https://pypi.org/project/fandango-fuzzer/1.1.0rc1/\" style=\"color:white;\">Fandango 1.1.0rc1</a> is now available! Check out the <a href=\"https://fandango-fuzzer.github.io/ReleaseNotes.html#\" style=\"color:white;\">release notes</a> for details."
 
 repository:
   url: "https://github.com/fandango-fuzzer/fandango"


### PR DESCRIPTION
This pull request adds an announcement banner for 1.1.0rc1 on top of each docs page:

> [Fandango 1.1.0rc1](https://pypi.org/project/fandango-fuzzer/1.1.0rc1/) is now available! Check out the [release notes](https://fandango-fuzzer.github.io/ReleaseNotes.html#) for details.