### PR TITLE
Quickfix to make a CI test occupy less ram

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -28,4 +28,4 @@ jobs:
       # Run tests or coverage depending on branch and OS
       - name: Run tests
         run: |
-          pytest -v -n 2
+          pytest -v

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -28,4 +28,4 @@ jobs:
       # Run tests or coverage depending on branch and OS
       - name: Run tests
         run: |
-          pytest -v
+          pytest -v -n 2

--- a/src/fandango/api.py
+++ b/src/fandango/api.py
@@ -115,6 +115,7 @@ class FandangoBase(ABC):
         self,
         max_generations: Optional[int] = None,
         mode: FuzzingMode = FuzzingMode.COMPLETE,
+        **settings: Any,
     ) -> Generator[DerivationTree, None, None]:
         """
         Generate trees that conform to the language.
@@ -271,6 +272,7 @@ class Fandango(FandangoBase):
         self,
         max_generations: Optional[int] = None,
         mode: FuzzingMode = FuzzingMode.COMPLETE,
+        **settings: Any,
     ) -> Generator[DerivationTree, None, None]:
         """
         Generate trees that conform to the language.
@@ -282,7 +284,7 @@ class Fandango(FandangoBase):
         :return: A generator for solutions to the language
         """
         if self.fandango is None:
-            self.init_population()
+            self.init_population(**settings)
             assert self.fandango is not None
 
         LOGGER.info(

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -61,7 +61,9 @@ def test_generate_with_single_soft_constraint(benchmark: BenchmarkFixture):
         fan = Fandango._with_parsed(grammar, constraints)
         # make this a non-limiting factor
         max_generations = 10000
-        gen = fan.generate_solutions(max_generations=max_generations)
+        gen = fan.generate_solutions(
+            max_generations=max_generations, max_repetition_rate=0.0, max_nodes_rate=0.0
+        )
         truncated_gen = itertools.islice(gen, 50)
         solutions = []
         for solution in truncated_gen:


### PR DESCRIPTION
Quick fix in order to make all CI tests running on Windows.
Set max_repetition_rate and max_nodes_rate to 0 in order to make the test occupy less memory.