### PR TITLE
Prevent runaway processes

### DIFF
--- a/docs/Protocols.md
+++ b/docs/Protocols.md
@@ -100,10 +100,11 @@ $ python -m aiosmtpd -d -n &
 ```{code-cell}
 :tags: ["remove-input"]
 import os
+import subprocess
+import sys
 import time
 
-os.system("pkill -f aiosmtpd")
-os.system("python -m aiosmtpd -n &")
+aiosmtpd_proc = subprocess.Popen([sys.executable, "-m", "aiosmtpd", "-n"])
 time.sleep(2);  # Wait for server to be ready
 ```
 
@@ -337,10 +338,10 @@ $ fandango talk -f smtp-simple.fan -n 100 --server 8125
 :tags: ["remove-input"]
 
 import os
+import subprocess
 import time
 
-os.system("pkill -f smtp-simple.fan")
-os.system("fandango talk -f smtp-simple.fan -n 100 --server 8125 &")
+fan_smtp_proc = subprocess.Popen(["fandango", "talk", "-f", "smtp-simple.fan", "-n", "100", "--server", "8125"])
 time.sleep(5);  # Wait for server to be ready
 ```
 
@@ -563,6 +564,8 @@ That's it for now. GO and thoroughly test your programs!
 % Let's kill our server(s)
 ```{code-cell}
 :tags: ["remove-input"]
-os.system("pkill -f aiosmtpd")
-os.system("pkill -f smtp-simple.fan");
+aiosmtpd_proc.terminate()
+fan_smtp_proc.terminate()
+aiosmtpd_proc.wait()
+fan_smtp_proc.wait();
 ```

--- a/docs/minitelnet.py
+++ b/docs/minitelnet.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
 import socket
-import os
+import subprocess
 import time
 import re
+import sys
 
 
 def sanitize_hostname(s: str, alt_hostname: str = "smtp.example.com") -> str:
@@ -38,11 +39,11 @@ def telnet(commands: list[str], port=8025, host="localhost"):
 
 
 if __name__ == "__main__":
-    os.system("pkill -f aiosmtpd")
-    os.system("python -m aiosmtpd -n &")
+    smtp_proc = subprocess.Popen([sys.executable, "-m", "aiosmtpd", "-n"])
     time.sleep(0.5)  # Give the server a moment to start
 
     commands = ["HELO relay.example.org\r\n", "QUIT\r\n"]
     telnet(commands)
 
-    os.system("pkill -f aiosmtpd")
+    smtp_proc.terminate()
+    smtp_proc.wait()


### PR DESCRIPTION
Depends on #764

We shouldn't randomly start and then kill processes in the docs, but instead properly manage our processes.