### PR TITLE
Only test 5 random specs in differential spec file parser tests for performance reasons

### DIFF
--- a/tests/test_fan_parsers.py
+++ b/tests/test_fan_parsers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env pytest
 
 import glob
+import random
 import unittest
 
 import pytest
@@ -8,11 +9,15 @@ import pytest
 from .utils import RESOURCES_ROOT, DOCS_ROOT, run_command
 
 files = glob.glob(str(RESOURCES_ROOT / "*.fan")) + glob.glob(str(DOCS_ROOT / "*.fan"))
+diff_probability = 5 / len(files)  # Randomly test about 5 files
 
 
 @pytest.mark.parametrize("fan_file", files)
 def test_file(fan_file):
     """Test the C++ and python .fan parsers for `fan_file`."""
+
+    if random.random() > diff_probability:
+        pytest.skip("Skipping file due to diff probability")
 
     command = ["fandango", "-v", "--parser=python", "convert", fan_file]
     python_out, err, return_code = run_command(command)
@@ -24,9 +29,8 @@ def test_file(fan_file):
     assert return_code == 0, err
     assert err == ""
 
-    assert (
-        python_out == cpp_out
-    ), f"{fan_file} produced different outputs for Python and C++ parsers:\n\nPython output:\n{python_out}\n\nC++ output:\n{cpp_out}"
+    msg = f"{fan_file} produced different outputs for Python and C++ parsers:\n\nPython output:\n{python_out}\n\nC++ output:\n{cpp_out}"
+    assert python_out == cpp_out, msg
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a quick-and-dirty fix for #840, but we should probably hand select some tests instead of just randomly sampling.