### PR TITLE
Prioritize Execution Feedback unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ def pytest_collection_modifyitems(items: list[pytest.Item]):
         "evaluation",
         "cli",
         "softconstraint",
+        "execution_feedback",
         "optimizer",
         "fan_parsers",
     ]


### PR DESCRIPTION
Some Execution Feedback unit tests take >30s. Running them early prevents the situation where all but one cores are sitting around drinking beer (to quote a previous professor of mine) while the last one is still busy running this test.