### PR TITLE
Update scikit-build-core and remove no longer necessary hacks

### DIFF
--- a/pylock.toml
+++ b/pylock.toml
@@ -2384,10 +2384,10 @@ wheels = [
 
 [[packages]]
 name = "scikit-build-core"
-version = "0.12.2"
+version = "1.0.2"
 index = "https://pypi.org/simple"
-sdist = { url = "https://files.pythonhosted.org/packages/28/cd/9ebb50029b6d8a3ee9e38cdce514ebd70190ec1edf28ab0a1f66d0b84670/scikit_build_core-0.12.2.tar.gz", upload-time = 2026-03-05T18:25:57Z, size = 303553, hashes = { sha256 = "562e0bbc9de1a354c87825ccf732080268d6582a0200f648e8c4a2dcb1e3736d" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/07/49/b2f0fbe3165d55c02e7f9eec6a10685d518af0ef6e919ff2f589c2d15c85/scikit_build_core-0.12.2-py3-none-any.whl", upload-time = 2026-03-05T18:25:56Z, size = 192625, hashes = { sha256 = "6ea4730da400f9a998ec3287bd3ebc1d751fe45ad0a93451bead8618adbc02b1" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/86/24/127c8523aba8651e1ab6c93a6710cb4991224851529fc15c3e8770213e6d/scikit_build_core-1.0.2.tar.gz", upload-time = 2026-07-09T16:21:20Z, size = 469825, hashes = { sha256 = "ade206d443a6610870bc2e31c89a17f9e14068eb5215cd49d249c986655011c7" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/2d/e2/138d376fe4046afd94760f30ab7a684149bbe6300b25701f7f7ab99cd5a4/scikit_build_core-1.0.2-py3-none-any.whl", upload-time = 2026-07-09T16:21:19Z, size = 275968, hashes = { sha256 = "847d626591f7fdd0956e146f265f9bb108911fc76a6582d9c5be9c6dcfbc8d3c" } }]
 
 [[packages]]
 name = "setuptools"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.11.6"]
+requires = ["scikit-build-core>=1.0.2"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
@@ -83,11 +83,11 @@ development = [
     "matplotlib>=3.10.0",
     "mypy>=1.16.0",
     "pre-commit>=4.2.0",
-    "pygls>=2.0.0a4",            # language server
+    "pygls>=2.0.0a4",           # language server
     "ruff>=0.14.0",
-    "scikit-build-core>=0.11.6",
+    "scikit-build-core>=1.0.2",
     "speedy-antlr-tool>=1.4.3",
-    "types-cachetools>=5.5.2",   # enable mypy to check cachetools
+    "types-cachetools>=5.5.2",  # enable mypy to check cachetools
 ]
 
 book = [

--- a/src/fandango/__init__.py
+++ b/src/fandango/__init__.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
-# needs to be before any other imports
 import os
 
 from fandango.beartype import activate_beartype
 
+# needs to be before any other imports
 if os.environ.get("FANDANGO_RUN_BEARTYPE", False):
     activate_beartype()
 

--- a/src/fandango/beartype.py
+++ b/src/fandango/beartype.py
@@ -1,28 +1,6 @@
-def _is_fandango_editable_redirect_finder(finder: object) -> bool:
-    """True for this package's scikit-build-core redirect editable finder only."""
-    if type(finder).__name__ not in {
-        "ScikitBuildRedirectingFinder",
-        "ScikitBuildInplaceFinder",
-    }:
-        return False
-    return "fandango" in getattr(finder, "pkgs", ())
-
-
 def activate_beartype() -> None:
-    import sys
-
     from beartype import BeartypeConf
     from beartype.claw import beartype_this_package
-
-    # scikit-build-core's redirect editable finder loads modules in a way that
-    # bypasses beartype.claw; drop ours so normal imports from src/ work (#556).
-    # The C++ parser extension is installed as a top-level module (see
-    # CMakeLists.txt) and does not rely on the redirect finder.
-    sys.meta_path[:] = [
-        finder
-        for finder in sys.meta_path
-        if not _is_fandango_editable_redirect_finder(finder)
-    ]
 
     skip_packages = (
         "fandango.language.grammar.grammar",  # GrammarProcessor sometimes passes searches instead of NonTerminalNodes to Grammar.set_generator

--- a/uv.lock
+++ b/uv.lock
@@ -131,7 +131,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "sortedcontainers", marker = "python_full_version < '3.12'" },
+    { name = "sortedcontainers" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/c9/4e7a3100197ce6658d0c287ab51061a709603f43ac7976e9f5740533aa17/astar-0.99-py3-none-any.whl", hash = "sha256:4d6e9bf8e90543d38cde7d90e873db78c5132247959c2d65abb8ac9d7e666aaf", size = 6635, upload-time = "2023-06-16T08:28:01.608Z" },
@@ -260,7 +260,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -918,7 +918,7 @@ requires-dist = [
     { name = "python-dateutil", marker = "extra == 'test'", specifier = ">=2.9.0.post0" },
     { name = "regex", specifier = ">=2024.11.6" },
     { name = "ruff", marker = "extra == 'development'", specifier = ">=0.14.0" },
-    { name = "scikit-build-core", marker = "extra == 'development'", specifier = ">=0.11.6" },
+    { name = "scikit-build-core", marker = "extra == 'development'", specifier = ">=1.0.2" },
     { name = "speedy-antlr-tool", marker = "extra == 'development'", specifier = ">=1.4.3" },
     { name = "sphinxcontrib-mermaid", marker = "extra == 'book'", specifier = ">=1.0.0" },
     { name = "tccbox", marker = "extra == 'test'", specifier = ">=2025.6.6" },
@@ -2167,7 +2167,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3076,15 +3076,15 @@ wheels = [
 
 [[package]]
 name = "scikit-build-core"
-version = "0.12.2"
+version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/cd/9ebb50029b6d8a3ee9e38cdce514ebd70190ec1edf28ab0a1f66d0b84670/scikit_build_core-0.12.2.tar.gz", hash = "sha256:562e0bbc9de1a354c87825ccf732080268d6582a0200f648e8c4a2dcb1e3736d", size = 303553, upload-time = "2026-03-05T18:25:57.666Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/24/127c8523aba8651e1ab6c93a6710cb4991224851529fc15c3e8770213e6d/scikit_build_core-1.0.2.tar.gz", hash = "sha256:ade206d443a6610870bc2e31c89a17f9e14068eb5215cd49d249c986655011c7", size = 469825, upload-time = "2026-07-09T16:21:20.969Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/49/b2f0fbe3165d55c02e7f9eec6a10685d518af0ef6e919ff2f589c2d15c85/scikit_build_core-0.12.2-py3-none-any.whl", hash = "sha256:6ea4730da400f9a998ec3287bd3ebc1d751fe45ad0a93451bead8618adbc02b1", size = 192625, upload-time = "2026-03-05T18:25:56.207Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e2/138d376fe4046afd94760f30ab7a684149bbe6300b25701f7f7ab99cd5a4/scikit_build_core-1.0.2-py3-none-any.whl", hash = "sha256:847d626591f7fdd0956e146f265f9bb108911fc76a6582d9c5be9c6dcfbc8d3c", size = 275968, upload-time = "2026-07-09T16:21:19.601Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`scikit-build-core` shipped an update that no longer requires our dirty hacks presumably.

See https://github.com/scikit-build/scikit-build-core/issues/1492.