### PR TITLE
Fix --warnings-are-errors

### DIFF
--- a/src/fandango/api.py
+++ b/src/fandango/api.py
@@ -13,7 +13,7 @@ from fandango.language.grammar import FuzzingMode, ParsingMode
 from fandango.language.grammar.grammar import Grammar
 from fandango.language.parse.parse import parse
 from fandango.language.tree import DerivationTree
-from fandango.logger import LOGGER
+from fandango.logger import LOGGER, set_raise_on_logged_exceptions
 
 DEFAULT_MAX_GENERATIONS = 500
 
@@ -248,6 +248,8 @@ class Fandango(FandangoBase):
         LOGGER.info("---------- Initializing base population ----------")
 
         start_symbol = settings.pop("start_symbol", self._start_symbol)
+        if settings.pop("warnings_are_errors", False):
+            set_raise_on_logged_exceptions(True)
 
         constraints = [] if skip_base_constraints else self.constraints[:]
 

--- a/src/fandango/cli/__init__.py
+++ b/src/fandango/cli/__init__.py
@@ -9,7 +9,7 @@ from fandango.cli.parser import get_parser
 from fandango.cli.shell import shell_command
 from fandango.cli.upgrade import check_for_fandango_update
 from fandango.experimental import dont_warn_about_module
-from fandango.logger import LOGGER
+from fandango.logger import LOGGER, set_raise_on_logged_exceptions
 
 
 def main(
@@ -28,6 +28,9 @@ def main(
 
     parser = get_parser(in_command_line=True)
     args = parser.parse_args(argv or sys.argv[1:])
+
+    if getattr(args, "warnings_are_errors", None):
+        set_raise_on_logged_exceptions(True)
 
     LOGGER.setLevel(os.getenv("FANDANGO_LOG_LEVEL", "WARNING"))  # Default
 

--- a/src/fandango/evolution/algorithm/base.py
+++ b/src/fandango/evolution/algorithm/base.py
@@ -44,7 +44,6 @@ class GeneticAlgorithm(ABC):
         mutation_rate: float = 0.2,
         destruction_rate: float = 0.0,
         logger_level: Optional[LoggerLevel] = None,
-        warnings_are_errors: bool = False,
         best_effort: bool = False,
         random_seed: Optional[int] = None,
         start_symbol: str = "<start>",

--- a/src/fandango/evolution/algorithm/simple.py
+++ b/src/fandango/evolution/algorithm/simple.py
@@ -56,7 +56,6 @@ class SimpleGeneticAlgorithm(GeneticAlgorithm):
         mutation_rate: float = 0.2,
         destruction_rate: float = 0.0,
         logger_level: Optional[LoggerLevel] = None,
-        warnings_are_errors: bool = False,
         best_effort: bool = False,
         random_seed: Optional[int] = None,
         start_symbol: str = "<start>",
@@ -91,7 +90,6 @@ class SimpleGeneticAlgorithm(GeneticAlgorithm):
         self.destruction_rate = destruction_rate
         self.start_symbol = start_symbol
         self.tournament_size = tournament_size
-        self.warnings_are_errors = warnings_are_errors
         self.best_effort = best_effort
         self.current_max_nodes = max_nodes
         self.diversity_k = diversity_k
@@ -106,7 +104,6 @@ class SimpleGeneticAlgorithm(GeneticAlgorithm):
             self.population_manager: PopulationManager = IoPopulationManager(
                 grammar,
                 start_symbol,
-                warnings_are_errors,
             )
             self.evaluator: Evaluator = IoEvaluator(
                 grammar,
@@ -114,13 +111,11 @@ class SimpleGeneticAlgorithm(GeneticAlgorithm):
                 expected_fitness,
                 diversity_k,
                 diversity_weight,
-                warnings_are_errors,
             )
         else:
             self.population_manager = PopulationManager(
                 grammar,
                 start_symbol,
-                warnings_are_errors,
             )
             self.evaluator = Evaluator(
                 grammar,
@@ -128,7 +123,6 @@ class SimpleGeneticAlgorithm(GeneticAlgorithm):
                 expected_fitness,
                 diversity_k,
                 diversity_weight,
-                warnings_are_errors,
                 stop_criterion,
                 use_fcc,
                 put,

--- a/src/fandango/evolution/evaluation.py
+++ b/src/fandango/evolution/evaluation.py
@@ -31,7 +31,6 @@ class Evaluator:
         expected_fitness: float,
         diversity_k: int,
         diversity_weight: float,
-        warnings_are_errors: bool = False,
         stop_criterion: Optional[Callable[[DerivationTree], bool]] = None,
         use_fcc: bool = False,
         put: Optional[str] = None,
@@ -44,7 +43,6 @@ class Evaluator:
         self._expected_fitness = expected_fitness
         self._diversity_k = diversity_k
         self._diversity_weight = diversity_weight
-        self._warnings_are_errors = warnings_are_errors
         self._fitness_cache: LRUCache[
             int, tuple[float, list[FailingTree], Suggestion]
         ] = LRUCache(maxsize=cache_size())
@@ -344,7 +342,6 @@ class IoEvaluator(Evaluator):
         expected_fitness: float,
         diversity_k: int,
         diversity_weight: float,
-        warnings_are_errors: bool = False,
     ):
         super().__init__(
             grammar,
@@ -352,7 +349,6 @@ class IoEvaluator(Evaluator):
             expected_fitness,
             diversity_k,
             diversity_weight,
-            warnings_are_errors,
         )
         self._submitted_solutions: set[int] = set()
         self._hold_back_solutions: set[DerivationTree] = set()

--- a/src/fandango/evolution/population.py
+++ b/src/fandango/evolution/population.py
@@ -17,11 +17,9 @@ class PopulationManager:
         self,
         grammar: Grammar,
         start_symbol: str,
-        warnings_are_errors: bool = False,
     ):
         self._grammar = grammar
         self._start_symbol = start_symbol
-        self._warnings_are_errors = warnings_are_errors
 
     def _generate_population_entry(self, max_nodes: int) -> DerivationTree:
         return self._grammar.fuzz(self._start_symbol, max_nodes)
@@ -135,9 +133,8 @@ class IoPopulationManager(PopulationManager):
         self,
         grammar: Grammar,
         start_symbol: str,
-        warnings_are_errors: bool = False,
     ):
-        super().__init__(grammar, start_symbol, warnings_are_errors)
+        super().__init__(grammar, start_symbol)
         self._prev_packet_idx = 0
         self.fuzzable_packets: list[ForecastingPacket] = []
         self.fallback_packets: list[ForecastingPacket] = []

--- a/src/fandango/logger.py
+++ b/src/fandango/logger.py
@@ -22,6 +22,23 @@ logging.basicConfig(
     format="%(name)s:%(levelname)s: %(message)s",
 )
 
+# When True, print_exception re-raises after logging.
+# Initialized from FANDANGO_RAISE_ALL_EXCEPTIONS (must be set before import);
+# also enabled by --warnings-are-errors / warnings_are_errors=True.
+_RAISE_ON_LOGGED_EXCEPTIONS: bool = bool(
+    os.environ.get("FANDANGO_RAISE_ALL_EXCEPTIONS", False)
+)
+
+
+def set_raise_on_logged_exceptions(enabled: bool) -> None:
+    """Re-raise exceptions that would otherwise only be logged by print_exception."""
+    global _RAISE_ON_LOGGED_EXCEPTIONS
+    _RAISE_ON_LOGGED_EXCEPTIONS = enabled
+
+
+def raise_on_logged_exceptions() -> bool:
+    return _RAISE_ON_LOGGED_EXCEPTIONS
+
 
 def print_exception(e: Exception, exception_note: Optional[str] = None) -> None:
     if exception_note is not None:
@@ -43,10 +60,7 @@ def print_exception(e: Exception, exception_note: Optional[str] = None) -> None:
             "  Convert <symbol> to the expected type, say 'str(<symbol>)', 'int(<symbol>)', or 'bytes(<symbol>)'",
             file=sys.stderr,
         )
-    if os.environ.get("FANDANGO_RAISE_ALL_EXCEPTIONS"):
-        raise e
-
-    if os.environ.get("FANDANGO_RAISE_ALL_EXCEPTIONS"):
+    if raise_on_logged_exceptions():
         raise e
 
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -70,7 +70,6 @@ class GeneticTest(unittest.TestCase):
         manager = PopulationManager(
             grammar=self.fandango.grammar,
             start_symbol=self.fandango.start_symbol,
-            warnings_are_errors=True,
         )
         population: list[DerivationTree] = []
         expected_count = 10
@@ -96,7 +95,6 @@ class GeneticTest(unittest.TestCase):
         manager = PopulationManager(
             grammar=self.fandango.grammar,
             start_symbol=self.fandango.start_symbol,
-            warnings_are_errors=True,
         )
 
         initial_count = 10


### PR DESCRIPTION
- `--warnings-are-errors` previously didn't raise exceptions in e.g. constraints but just print them as warnings.
- We were also needlessly passing around a `warnings_are_errors` argument through the algorithm and nested classes. Cleaned up here.