### PR TITLE
Rework the contributing guide and add the community health files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,9 @@
-# EditorConfig helps keep formatting consistent across editors.
+# EditorConfig keeps basic file hygiene consistent across editors.
 # See https://editorconfig.org
 #
-# These settings match the Ruff configuration in pyproject.toml, so your editor
-# and `ruff format` agree. Ruff remains the source of truth for Python.
+# Deliberately minimal. Ruff is the source of truth for Python formatting
+# (indentation, line length), so those are not repeated here: duplicating them
+# only creates two places to disagree. This file covers what Ruff does not.
 
 root = true
 
@@ -12,25 +13,14 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
-indent_size = 4
-
-[*.py]
-indent_size = 4
-max_line_length = 88
-
-[*.{yml,yaml,json,toml}]
-indent_size = 2
 
 [*.{md,fan}]
-indent_size = 4
-# Markdown uses trailing double-space for hard line breaks, and .fan specs are
-# whitespace-significant, so leave trailing whitespace alone in both.
+# Markdown uses a trailing double space for hard line breaks, and .fan specs
+# are whitespace-significant.
 trim_trailing_whitespace = false
 
-[*.g4]
-indent_size = 4
-
 [Makefile]
+# Tabs are required here, not a preference.
 indent_style = tab
 
 [*.{bat,ps1}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,37 @@
+# EditorConfig helps keep formatting consistent across editors.
+# See https://editorconfig.org
+#
+# These settings match the Ruff configuration in pyproject.toml, so your editor
+# and `ruff format` agree. Ruff remains the source of truth for Python.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.py]
+indent_size = 4
+max_line_length = 88
+
+[*.{yml,yaml,json,toml}]
+indent_size = 2
+
+[*.{md,fan}]
+indent_size = 4
+# Markdown uses trailing double-space for hard line breaks, and .fan specs are
+# whitespace-significant, so leave trailing whitespace alone in both.
+trim_trailing_whitespace = false
+
+[*.g4]
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[*.{bat,ps1}]
+end_of_line = crlf

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,7 +46,9 @@ body:
     id: output
     attributes:
       label: The full output
-      description: The complete error message and traceback, not just the last line.
+      description: >-
+        The complete error message and traceback, not just the last line.
+        Running the command with `-v` adds useful debugging information.
       render: shell
     validations:
       required: true
@@ -56,7 +58,7 @@ body:
     attributes:
       label: Fandango version
       description: The output of `fandango --version`.
-      placeholder: Fandango 1.1.1
+      placeholder: Fandango x.x.x
     validations:
       required: true
 
@@ -64,7 +66,7 @@ body:
     id: python-os
     attributes:
       label: Python version and operating system
-      placeholder: Python 3.13.5 on macOS 15.2
+      placeholder: Python 3.x.x on macOS x.x
     validations:
       required: true
 
@@ -75,5 +77,5 @@ body:
       options:
         - label: I searched the existing issues and did not find this
           required: false
-        - label: I am using a supported Python version (3.11 or later)
+        - label: I checked that this still happens on the current `main` branch
           required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug report
+description: Something in Fandango does not behave the way it should
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this.
+
+        **Found a security vulnerability?** Please do not file it here.
+        Report it privately with GitHub's [security advisory form](https://github.com/fandango-fuzzer/fandango/security/advisories/new).
+        See [SECURITY.md](https://github.com/fandango-fuzzer/fandango/blob/main/SECURITY.md).
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what did you get instead?
+      placeholder: |
+        I expected Fandango to generate inputs matching my grammar, but it
+        exited with an error instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: spec
+    attributes:
+      label: The spec
+      description: >
+        The smallest `.fan` spec that still shows the problem. Reducing it is
+        the single most useful thing you can do to get this fixed quickly.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: command
+    attributes:
+      label: The command you ran
+      placeholder: fandango fuzz -f my_spec.fan -n 10
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: output
+    attributes:
+      label: The full output
+      description: The complete error message and traceback, not just the last line.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Fandango version
+      description: The output of `fandango --version`.
+      placeholder: Fandango 1.1.1
+    validations:
+      required: true
+
+  - type: input
+    id: python-os
+    attributes:
+      label: Python version and operating system
+      placeholder: Python 3.13.5 on macOS 15.2
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing issues and did not find this
+          required: false
+        - label: I am using a supported Python version (3.11 or later)
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://fandango-fuzzer.github.io/
+    about: The Fandango book, including the hands-on tutorial and the reference.
+  - name: Report a security vulnerability
+    url: https://github.com/fandango-fuzzer/fandango/security/advisories/new
+    about: Report privately via GitHub security advisories, not as a public issue.
+  - name: Contributing guide
+    url: https://fandango-fuzzer.github.io/Contributing.html
+    about: How to set up a development environment and open a pull request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature request
+description: Suggest something Fandango should be able to do
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Describing the problem you ran into is more
+        useful than describing a solution, because it leaves room for an
+        approach you may not have considered.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: >
+        What were you doing when you needed this? What did you try, and where
+        did it fall short?
+      placeholder: >
+        I am specifying a format where a field's value depends on a checksum of
+        two other fields, and I could not find a way to express that.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like Fandango to do?
+      description: If you have a concrete idea, sketch it. A `.fan` snippet helps.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      description: >
+        Including "I worked around it like this", which is useful for judging how
+        much the feature would buy.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing issues and did not find this
+          required: false
+        - label: I would be willing to work on this myself
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,14 +5,14 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for the suggestion. Describing the problem you ran into is more
-        useful than describing a solution, because it leaves room for an
+        Thanks for the suggestion. Telling us what you were trying to do is
+        more useful than proposing a solution, because it leaves room for an
         approach you may not have considered.
 
   - type: textarea
-    id: problem
+    id: goal
     attributes:
-      label: What problem are you trying to solve?
+      label: What are you trying to do?
       description: >
         What were you doing when you needed this? What did you try, and where
         did it fall short?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,53 @@
+<!--
+Thanks for contributing to Fandango!
+
+The full guide is at https://fandango-fuzzer.github.io/Contributing.html
+Nothing below is mandatory, but a reviewer who can see what changed and why
+will get to your pull request faster.
+-->
+
+## What does this change?
+
+<!-- A short description. If it fixes an issue, write "Fixes #123" so GitHub
+     closes it on merge. -->
+
+## Why?
+
+<!-- The reasoning matters more than the diff, which already shows the what.
+     If there was a design choice with a real alternative, mention it. -->
+
+## How was it tested?
+
+<!-- New tests, existing tests, manual steps. If behaviour changed, a test that
+     fails before this change and passes after is the most convincing thing you
+     can point at. -->
+
+## Checklist
+
+- [ ] The change does one thing
+- [ ] Tests cover any changed behaviour
+- [ ] Documentation updated, if this changes something a user can see
+- [ ] `pre-commit` passes (`pre-commit run --all-files`)
+- [ ] `make tests` passes locally (note the plural)
+- [ ] `make lock` was run, if `pyproject.toml` dependencies changed
+- [ ] I have read every line of this change and can explain it in review
+
+<!--
+That last box is the one that matters most. Use whatever tools you like,
+including AI, but the code is yours: you should be able to say why it is
+written this way and why it is correct. See "Using AI assistance" in
+CONTRIBUTING.md.
+-->
+
+<!--
+Working from an issue? Please make sure it was assigned to you first. If it was
+already assigned to someone else, we will most likely close this in favour of
+their work, which is a waste of your time.
+-->
+
+
+<!--
+CI checks formatting and types across the WHOLE repository, not just src/, so a
+stray file elsewhere can turn the build red. Running pre-commit locally catches
+almost all of it.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,53 +1,22 @@
-<!--
-Thanks for contributing to Fandango!
+<!-- Guide: https://fandango-fuzzer.github.io/Contributing.html
+     Working from an issue? Please get it assigned to you first. -->
 
-The full guide is at https://fandango-fuzzer.github.io/Contributing.html
-Nothing below is mandatory, but a reviewer who can see what changed and why
-will get to your pull request faster.
--->
+## What and why
 
-## What does this change?
-
-<!-- A short description. If it fixes an issue, write "Fixes #123" so GitHub
-     closes it on merge. -->
-
-## Why?
-
-<!-- The reasoning matters more than the diff, which already shows the what.
-     If there was a design choice with a real alternative, mention it. -->
+<!-- The diff shows what changed, so the why matters more.
+     Fixes #123 -->
 
 ## How was it tested?
 
-<!-- New tests, existing tests, manual steps. If behaviour changed, a test that
-     fails before this change and passes after is the most convincing thing you
-     can point at. -->
+<!-- New tests, existing tests, or manual steps. -->
 
 ## Checklist
 
-- [ ] The change does one thing
+- [ ] Does one thing, and the diff is limited to what that needs
 - [ ] Tests cover any changed behaviour
-- [ ] Documentation updated, if this changes something a user can see
-- [ ] `pre-commit` passes (`pre-commit run --all-files`)
-- [ ] `make tests` passes locally (note the plural)
+- [ ] Docs updated, if this changes something a user can see
+- [ ] `pre-commit` and `make tests` pass locally
 - [ ] `make lock` was run, if `pyproject.toml` dependencies changed
-- [ ] I have read every line of this change and can explain it in review
-
-<!--
-That last box is the one that matters most. Use whatever tools you like,
-including AI, but the code is yours: you should be able to say why it is
-written this way and why it is correct. See "Using AI assistance" in
-CONTRIBUTING.md.
--->
-
-<!--
-Working from an issue? Please make sure it was assigned to you first. If it was
-already assigned to someone else, we will most likely close this in favour of
-their work, which is a waste of your time.
--->
-
-
-<!--
-CI checks formatting and types across the WHOLE repository, not just src/, so a
-stray file elsewhere can turn the build red. Running pre-commit locally catches
-almost all of it.
--->
+- [ ] I understand what every changed line does and why it is there
+- [ ] I wrote this description myself, and said above if the change was
+      substantially AI-assisted

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,56 @@
+cff-version: 1.2.0
+message: >-
+  If you use Fandango in your research, please cite the ISSTA 2025 paper below
+  rather than this repository.
+title: Fandango
+abstract: >-
+  Fandango is a generator of inputs and interactions for software testing. Given
+  a specification of a program's input or interaction language, combining a
+  grammar with constraints written in Python, Fandango generates myriads of
+  valid inputs using an evolutionary search.
+type: software
+license: EUPL-1.2
+repository-code: https://github.com/fandango-fuzzer/fandango
+url: https://fandango-fuzzer.github.io/
+keywords:
+  - language-based testing
+  - fuzzing
+  - test generation
+  - grammars
+authors:
+  - given-names: José Antonio
+    family-names: Zamudio Amaya
+    email: jose.zamudio@cispa.de
+    affiliation: CISPA Helmholtz Center for Information Security
+  - given-names: Marius
+    family-names: Smytzek
+    email: marius.smytzek@cispa.de
+    affiliation: CISPA Helmholtz Center for Information Security
+  - given-names: Andreas
+    family-names: Zeller
+    email: andreas.zeller@cispa.de
+    affiliation: CISPA Helmholtz Center for Information Security
+
+preferred-citation:
+  type: article
+  title: "FANDANGO: Evolving Language-Based Testing"
+  year: 2025
+  month: 6
+  doi: 10.1145/3728915
+  url: https://doi.org/10.1145/3728915
+  journal: Proceedings of the ACM on Software Engineering
+  volume: 2
+  issue: ISSTA
+  number: ISSTA040
+  publisher:
+    name: Association for Computing Machinery
+  authors:
+    - given-names: José Antonio
+      family-names: Zamudio Amaya
+      affiliation: CISPA Helmholtz Center for Information Security
+    - given-names: Marius
+      family-names: Smytzek
+      affiliation: CISPA Helmholtz Center for Information Security
+    - given-names: Andreas
+      family-names: Zeller
+      affiliation: CISPA Helmholtz Center for Information Security

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,52 @@
+# Code of Conduct
+
+## Our Standard
+
+Everyone participating in the Fandango project, including in our issue tracker,
+pull requests, discussions, and chat, is expected to treat other people with
+respect and to follow the [Python Community Code of
+Conduct](https://www.python.org/psf/codeofconduct/).
+
+In short, we are committed to being:
+
+- **Open.** We welcome contributors from any background and any level of
+  experience.
+- **Considerate.** People put work into what they contribute, and it is read by
+  others. Say what you mean, and assume the other person meant well.
+- **Respectful.** Disagreement is normal and useful. Personal attacks, dismissal,
+  and harassment are not.
+
+Unacceptable behaviour includes harassment, insulting or derogatory comments,
+personal or political attacks, publishing others' private information without
+permission, and unwelcome sexual attention.
+
+## Scope
+
+This applies in all project spaces, and also when an individual is representing
+the project in public.
+
+## Reporting
+
+If you experience or witness behaviour that breaks this code, report it to:
+
+**[fandango-fuzzer@protonmail.com](mailto:fandango-fuzzer@protonmail.com)**
+
+All reports are handled confidentially. We will acknowledge your report and let
+you know how we intend to respond. You are not expected to have evidence, or to
+be certain that what happened warrants a report, in order to raise it.
+
+Maintainers who do not follow or enforce this code in good faith may face
+consequences decided by the other maintainers.
+
+## Enforcement
+
+Maintainers may take any action they judge appropriate, including a private
+warning, a public correction, or a temporary or permanent ban from project
+spaces. Where possible we prefer to start with the least severe response that
+resolves the situation.
+
+## Attribution
+
+Adapted from the [Python Community Code of
+Conduct](https://www.python.org/psf/codeofconduct/), which Fandango follows, and
+which is itself informed by the [Contributor Covenant](https://www.contributor-covenant.org/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,19 +46,29 @@ If you later cannot finish it, say so and unassign yourself. That is fine.
 
 ## Using AI assistance
 
-We are not against AI tools, we use them too, and we do not ask you to declare
-them. But **you own the code you submit**: you should be able to explain why it
-is written that way, why it is correct, and what you rejected. If a reviewer
-asks about a decision and the honest answer is "the model wrote it", the pull
-request is not ready.
+We are not against AI tools, we use them too. Two things we ask, and one we
+require.
+
+**Tell us when you used one.** If a change was substantially AI-assisted, say so
+in the pull request. We cannot verify it and it will not count against you, but
+it tells a reviewer what kind of read the change needs.
+
+**Write the description yourself.** Generated descriptions are long and say
+little, and writing it in your own words is the fastest way to find out whether
+you understand the change.
+
+**You own the code you submit.** You should be able to say why it is written
+that way, why it is correct, and what you rejected. Make sure you understand
+what every changed line does and why it is there.
 
 The problem is not AI, it is moving your work onto the maintainers. A patch
 generated from an issue and pushed unread costs us more time than the issue
 would have. Those pull requests get inspected closely, and if the work has been
 handed to us rather than done, we close them.
 
-Read every line, run it, and be ready to defend it in review. Do that and we do
-not care how you got there.
+Keep the diff minimal too. Models like to reformat and rename things the change
+never needed to touch, and every unrelated hunk is more for a reviewer to rule
+out.
 
 ## Setting up
 
@@ -93,7 +103,9 @@ so a stray file elsewhere can fail the build. `pre-commit` catches almost all
 of it locally.
 
 If you change dependencies in `pyproject.toml`, regenerate both lockfiles with
-`make lock`, or CI will fail.
+`make lock`, or CI will fail. See
+[the guide](https://fandango-fuzzer.github.io/Contributing.html#lockfiles) for
+what these are and why we keep both.
 
 ## What makes a pull request easy to merge
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+# Contributing to Fandango
+
+Thanks for wanting to help. Fandango is a community project, and your
+experience using it is as valuable a contribution as code.
+
+**The full guide lives in the Fandango book:
+<https://fandango-fuzzer.github.io/Contributing.html>** (source:
+[`docs/Contributing.md`](docs/Contributing.md)). This file is the short version.
+
+## Before you start
+
+By participating you agree to follow our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+Found a **security vulnerability**? Do not open a public issue. Report it
+privately through GitHub's [security advisory form](https://github.com/fandango-fuzzer/fandango/security/advisories/new), or from the
+repository's Security tab. See [`SECURITY.md`](SECURITY.md).
+
+## Reporting a bug
+
+Open an [issue](https://github.com/fandango-fuzzer/fandango/issues/new/choose)
+and include:
+
+- the smallest `.fan` spec that still shows the problem, and the exact command
+  you ran,
+- what you expected, and what happened instead, with the full error output,
+- the output of `fandango --version`, plus your Python version and OS.
+
+## New to Fandango's specification language?
+
+Start with the [hands-on tutorial](https://fandango-fuzzer.github.io/HandsOn.html).
+It builds one small protocol from random bytes up to a stateful conversation, so
+by the end you have written the grammars, constraints, and feedback that most
+issues are about. It takes an afternoon and saves a round of review later.
+
+## Picking up an issue
+
+**If an issue is already assigned, please leave it** and pick another one.
+Someone is working on it.
+
+**If it is unassigned, comment on it before you start** and wait to be assigned.
+It lets us tell you if the issue is thornier than it looks, or already being
+handled elsewhere, which is much cheaper to hear before you write the code.
+
+If you later cannot finish it, say so and unassign yourself. That is fine.
+
+## Using AI assistance
+
+We are not against AI tools, we use them too, and we do not ask you to declare
+them. But **you own the code you submit**: you should be able to explain why it
+is written that way, why it is correct, and what you rejected. If a reviewer
+asks about a decision and the honest answer is "the model wrote it", the pull
+request is not ready.
+
+The problem is not AI, it is moving your work onto the maintainers. A patch
+generated from an issue and pushed unread costs us more time than the issue
+would have. Those pull requests get inspected closely, and if the work has been
+handed to us rather than done, we close them.
+
+Read every line, run it, and be ready to defend it in review. Do that and we do
+not care how you got there.
+
+## Setting up
+
+Fandango needs **Python 3.11 or later**. With
+[uv](https://docs.astral.sh/uv/) (recommended, this is what our CI uses):
+
+```shell
+git clone https://github.com/YOUR-USERNAME/fandango.git
+cd fandango
+make system-dev-tools          # ANTLR and a C++ compiler
+uv sync --all-extras --locked  # exactly the dependency set CI resolves
+```
+
+If the C++ parser fails to build, skip it and use the pure-Python fallback:
+
+```shell
+FANDANGO_SKIP_CPP_PARSER=1 uv sync --all-extras --locked
+```
+
+Prefer plain `pip`? See
+[the full guide](https://fandango-fuzzer.github.io/Contributing.html).
+
+## Before you open a pull request
+
+```shell
+pre-commit install   # once; then it runs on every commit
+make tests           # note the plural: `make test` does nothing
+```
+
+CI checks formatting and types across the **whole repository**, not just `src`,
+so a stray file elsewhere can fail the build. `pre-commit` catches almost all
+of it locally.
+
+If you change dependencies in `pyproject.toml`, regenerate both lockfiles with
+`make lock`, or CI will fail.
+
+## What makes a pull request easy to merge
+
+- It does one thing.
+- It explains **why**, not just what; the diff already shows the what.
+- It has a test for any behaviour it changes.
+- It updates the docs if it changes something a user can see.
+- It is green in CI.
+
+When a review asks for changes, push more commits rather than force-pushing a
+rewritten branch, so the review comments stay anchored. Pull requests are merged
+with a merge commit, so your branch's commits stay in the project history.
+
+## Licensing
+
+Fandango is released under the [European Union Public Licence v1.2](LICENSE.md).
+By contributing you agree your contribution is licensed under those same terms,
+and confirm you have the right to submit it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,9 @@ out.
 
 ## Setting up
 
-Fandango needs **Python 3.11 or later**. With
-[uv](https://docs.astral.sh/uv/) (recommended, this is what our CI uses):
+Fandango needs **Python 3.11 or later**. Fork the repository on GitHub first,
+then clone your fork. With [uv](https://docs.astral.sh/uv/) (recommended, this
+is what our CI uses):
 
 ```shell
 git clone https://github.com/YOUR-USERNAME/fandango.git
@@ -106,6 +107,25 @@ If you change dependencies in `pyproject.toml`, regenerate both lockfiles with
 `make lock`, or CI will fail. See
 [the guide](https://fandango-fuzzer.github.io/Contributing.html#lockfiles) for
 what these are and why we keep both.
+
+## Opening a pull request
+
+You work on your own fork, not on a branch of this repository:
+
+1. **Fork** the repository on GitHub.
+2. **Clone your fork** and set it up as in [Setting up](#setting-up) above.
+3. **Commit on a branch** and push it to your fork:
+
+   ```shell
+   git switch -c my-change
+   git commit -am "Say what changed and why"
+   git push -u origin my-change
+   ```
+
+4. **Open a pull request across forks**, from your branch on your fork to `main`
+   on `fandango-fuzzer/fandango`. GitHub offers this right after you push.
+
+You need nothing from us to start, and no push access here.
 
 ## What makes a pull request easy to merge
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,50 @@ Fandango is in active development! We are constantly expanding its capabilities.
 * High-diversity input generation
 * ...and much more!
 
+## Installation
+
+Fandango requires Python 3.11 or later:
+
+```shell
+$ pip install fandango-fuzzer
+```
+
+Then write a specification and generate inputs from it:
+
+```shell
+$ fandango fuzz -f your_spec.fan -n 10
+```
+
+See [Installing](https://fandango-fuzzer.github.io/Installing.html) for other
+options, including building from source.
+
 📚 **Ready to dive deeper?** For complete documentation, including tutorials, references, and advanced usage guides, visit the [Fandango Documentation](https://fandango-fuzzer.github.io/).
+
+New to Fandango? The [hands-on tutorial](https://fandango-fuzzer.github.io/HandsOn.html)
+takes one small protocol and works up from random bytes to a stateful
+conversation, one idea at a time.
+
+## Contributing
+
+Contributions are welcome, and reporting a bug or fixing a typo counts.
+
+* [**Contributing guide**](CONTRIBUTING.md) covers setting up a development
+  environment, what our CI checks, and how to get a pull request merged. Please
+  note that we ask you to comment on an issue and be assigned before starting
+  work on it.
+* [**Code of Conduct**](CODE_OF_CONDUCT.md) applies to everyone taking part.
+* [**Getting help**](SUPPORT.md) if something is unclear or not working.
+* [**Security policy**](SECURITY.md) for reporting vulnerabilities. Please
+  report these privately via GitHub's [security advisory form](https://github.com/fandango-fuzzer/fandango/security/advisories/new), not as a
+  public issue.
+
+## Citing Fandango
+
+If you use Fandango in academic work, please cite the ISSTA 2025 paper
+[*FANDANGO: Evolving Language-Based Testing*](https://doi.org/10.1145/3728915)
+by José Antonio Zamudio Amaya, Marius Smytzek, and Andreas Zeller. GitHub's
+"Cite this repository" button, backed by [`CITATION.cff`](CITATION.cff), gives
+you a ready-made BibTeX entry.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,28 @@ Contributions are welcome, and reporting a bug or fixing a typo counts.
 ## Citing Fandango
 
 If you use Fandango in academic work, please cite the ISSTA 2025 paper
-[*FANDANGO: Evolving Language-Based Testing*](https://doi.org/10.1145/3728915)
-by José Antonio Zamudio Amaya, Marius Smytzek, and Andreas Zeller. GitHub's
-"Cite this repository" button, backed by [`CITATION.cff`](CITATION.cff), gives
-you a ready-made BibTeX entry.
+[*FANDANGO: Evolving Language-Based Testing*](https://doi.org/10.1145/3728915).
+GitHub's "Cite this repository" button, backed by
+[`CITATION.cff`](CITATION.cff), generates this for you:
+
+```bibtex
+@article{zamudio2025fandango,
+  author  = {Zamudio Amaya, Jos\'{e} Antonio and Smytzek, Marius and Zeller, Andreas},
+  title   = {{FANDANGO}: {E}volving Language-Based Testing},
+  journal = {Proc. ACM Softw. Eng.},
+  volume  = {2},
+  number  = {ISSTA},
+  articleno = {ISSTA040},
+  numpages  = {23},
+  year    = {2025},
+  month   = jun,
+  doi     = {10.1145/3728915},
+  url     = {https://doi.org/10.1145/3728915},
+  publisher = {Association for Computing Machinery}
+}
+```
+
+Note that the first author's family name is "Zamudio Amaya".
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,33 +1,86 @@
 # Security Policy
 
+## Supported Versions
+
+Security fixes are made against the latest released version of Fandango. If you
+are reporting a vulnerability, please check first that it still reproduces on
+the current release.
+
 ## Reporting a Vulnerability
 
-If you find a security vulnerability in this project, we strongly encourage you to report it as soon as possible. Please follow the steps below:
+**Please report vulnerabilities privately, through GitHub, not as a public
+issue.**
 
-1. **Do not publicly disclose the vulnerability** until we have had a chance to address it.
-2. Contact us directly via **[fandango-fuzzer@protonmail.com](mailto:fandango-fuzzer@protonmail.com)** with the following details:
-   - A detailed description of the vulnerability.
-   - Steps to reproduce the issue, if applicable.
-   - The impact or potential impact of the vulnerability.
+Use the repository's private reporting form:
 
-We will confirm receipt of your report within 48 hours and provide a timeline for resolving the issue.
+**<https://github.com/fandango-fuzzer/fandango/security/advisories/new>**
 
----
+You can also reach it from the repository's **Security** tab, under **Report a
+vulnerability**. You need a GitHub account, and the report is visible only to
+you and the maintainers.
 
-## Security Measures
+We prefer this over email because it keeps the report, our questions, the fix,
+and the eventual advisory together in one private thread, and because it lets us
+request a CVE and credit you directly from that thread when the time comes.
 
-To help ensure the security of this project, we:
-- Use **best practices** for secure coding.
-- Regularly update dependencies to address vulnerabilities.
-- Monitor the project for potential security threats.
+Please include:
 
----
+- a description of the vulnerability and why you believe it is one,
+- steps to reproduce it, ideally with the smallest `.fan` spec or command that
+  triggers it,
+- the version of Fandango affected (`fandango --version`), plus your Python
+  version and operating system,
+- the impact you think it has, and any conditions required to exploit it.
+
+If you cannot use GitHub's form for any reason, contact
+[fandango-fuzzer@protonmail.com](mailto:fandango-fuzzer@protonmail.com) instead.
+Please do not include exploit details in a first email; just say that you have
+something to report and we will arrange a private channel.
+
+### What to expect
+
+- **Within 48 hours**: we acknowledge that we received your report.
+- **Within 7 days**: an initial assessment, whether we consider it a
+  vulnerability, and a rough timeline.
+- **Ongoing**: we keep you updated in the advisory thread as we work on a fix.
+
+Please give us a reasonable opportunity to fix the issue before disclosing it
+publicly. If you plan to publish on a fixed date, tell us early so we can work
+to it.
 
 ## Coordinated Disclosure
 
-We follow a coordinated disclosure process. Once a vulnerability has been verified and fixed, we will:
-1. Acknowledge the contribution of the reporter (if agreed upon).
-2. Publicly disclose the details in a **security advisory**.
-3. Notify affected users, if applicable.
+Once a vulnerability is verified and fixed, we will:
 
-Thank you for helping us keep this project secure.
+1. Publish a security advisory describing the issue and the affected versions.
+2. Credit you for the report, unless you would rather stay anonymous. Tell us
+   which you prefer.
+3. Release a fixed version and note the advisory in the
+   [release notes](https://fandango-fuzzer.github.io/ReleaseNotes.html).
+
+## Scope
+
+Fandango is a **testing tool**. It runs specifications you provide, and a `.fan`
+specification can contain arbitrary Python by design, which it executes. Running
+an untrusted specification is therefore equivalent to running untrusted code,
+and that is expected behaviour rather than a vulnerability.
+
+Reports we are interested in include, for example, Fandango being made to
+execute code or access resources that the specification it was given did not
+call for, a crash reachable from untrusted *input data* rather than from an
+untrusted specification, or a vulnerability in how Fandango handles credentials
+or network connections during protocol testing.
+
+If you are unsure whether something is in scope, report it anyway and say what
+you are unsure about. We would rather see it.
+
+## Security Measures
+
+To help keep this project secure, we:
+
+- keep dependencies current, with automated updates via Dependabot,
+- run CodeQL analysis on the codebase,
+- run the full test suite across supported Python versions on every pull
+  request.
+
+Thank you for helping keep Fandango secure.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,53 @@
+# Getting Help with Fandango
+
+## Start with the documentation
+
+The [Fandango book](https://fandango-fuzzer.github.io/) covers most questions:
+
+- [Installing Fandango](https://fandango-fuzzer.github.io/Installing.html)
+- [Your first specification](https://fandango-fuzzer.github.io/FirstSpec.html)
+- [Grammars and constraints](https://fandango-fuzzer.github.io/Constraints.html)
+- [Testing protocols](https://fandango-fuzzer.github.io/Protocols.html)
+- [Frequently asked questions](https://fandango-fuzzer.github.io/FAQ.html)
+
+If you are new, the [hands-on
+tutorial](https://fandango-fuzzer.github.io/HandsOn.html) builds one running
+example from random bytes up to a stateful protocol conversation.
+
+## Asking a question
+
+If the documentation does not answer it, open an
+[issue](https://github.com/fandango-fuzzer/fandango/issues). There is no
+separate forum, so questions are welcome on the tracker.
+
+You will get a better answer faster if you include:
+
+- the smallest `.fan` spec that shows what you are asking about,
+- the exact command you ran and its full output,
+- what you expected to happen instead,
+- the output of `fandango --version`, plus your Python version and OS.
+
+## Reporting a bug
+
+Use the [bug report
+template](https://github.com/fandango-fuzzer/fandango/issues/new/choose). See
+[CONTRIBUTING.md](CONTRIBUTING.md) for what makes a report easy to act on.
+
+## Reporting a security vulnerability
+
+Please do **not** open a public issue. Report it privately through GitHub's
+[security advisory form](https://github.com/fandango-fuzzer/fandango/security/advisories/new), or from the repository's Security tab. See
+[SECURITY.md](SECURITY.md).
+
+## Contributing a fix
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). Note that we ask you to comment on an
+issue and be assigned before starting work on it.
+
+## What we cannot help with
+
+We cannot debug your program under test for you, or write your specification
+from scratch. If your specification is not producing what you expect, reduce it
+to the smallest case that still shows the problem and ask about that; that is
+usually enough for us to see what is going on, and often enough for you to spot
+it yourself.

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -98,6 +98,10 @@ Fandango requires **Python 3.11 or later**. Our CI tests against Python 3.11,
 
 ### Step 1: Fork and clone
 
+You do not need push access to the Fandango repository, and you should not wait
+for it. All your work happens on your own fork, and reaches us as a [pull
+request across forks](sec:contributing-code).
+
 Fork the [Fandango repository](https://github.com/fandango-fuzzer/fandango) on
 GitHub, then clone your fork:
 
@@ -338,7 +342,31 @@ So before you open a pull request, whatever tools you used to get there:
 (sec:contributing-code)=
 ## Contributing Code
 
-We use the usual GitHub pull request flow. If it is unfamiliar, see [GitHub's
+We use the usual GitHub pull request flow, from a fork:
+
+1. **Fork** the [Fandango
+   repository](https://github.com/fandango-fuzzer/fandango) on GitHub. This
+   gives you your own copy, at `https://github.com/YOUR-USERNAME/fandango`.
+2. **Clone your fork** and set it up as described in [Setting up a development
+   environment](sec:getting-started-with-development).
+3. **Commit your change on a branch** in your fork, and push that branch:
+
+   ```shell
+   $ git switch -c my-change
+   $ git commit -am "Say what changed and why"
+   $ git push -u origin my-change
+   ```
+
+4. **Open a pull request across forks**: from your branch on your fork, to
+   `main` on `fandango-fuzzer/fandango`. GitHub offers this on your fork's page
+   right after you push, and you can also open it from the [main
+   repository](https://github.com/fandango-fuzzer/fandango/compare) by picking
+   your fork and branch as the source.
+
+Branches on the main repository itself are for the core developers, so this is
+the route for everyone else, and it needs nothing from us to get started.
+
+If any of this is unfamiliar, see [GitHub's
 documentation](https://docs.github.com/en/pull-requests).
 
 Anyone interested in Fandango may review your code, and one of the core

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -296,12 +296,23 @@ fails the build.
 (sec:ai-assistance)=
 ## Using AI Assistance
 
-We are not against AI tools and we do not ask you to declare that you used one.
-Plenty of good contributions are written with a model in the loop, and we use
-them ourselves.
+We are not against AI tools. Plenty of good contributions are written with a
+model in the loop, and we use them ourselves.
 
-What we do require is that **you own the code you submit**. You should be able
-to explain why the change is written the way it is, why it is correct, what
+Two things we ask.
+
+**Tell us when you used one.** If a change was substantially written with AI
+assistance, say so in the pull request. We cannot verify it and it will not
+count against you. It tells a reviewer what kind of read the change needs, which
+makes triage faster for everyone.
+
+**Write the description yourself.** Generated pull request and issue
+descriptions tend to be long and say little, which moves work onto the reader.
+Writing it in your own words is also the quickest way to find out whether you
+understand the change.
+
+And one thing we require: **you own the code you submit**. You should be able to
+say why the change is written the way it is, why it is correct, what
 alternatives you rejected, and what happens at the edges. If a reviewer asks
 about a decision and the honest answer would be "the model wrote it that way",
 the pull request is not ready to open.
@@ -313,19 +324,16 @@ than the issue would have. Reviewing that means reconstructing an intent that
 was never formed in the first place, which is harder than writing the fix from
 scratch. That is not a contribution, it is a transfer of effort.
 
-This is usually easy to spot. Pull requests that look this way will be
-inspected closely, and if it turns out the work has been handed to us rather
-than done, we will close them without merging.
+Keep the diff minimal while you are at it. Models like to reformat, rename, and
+"improve" code the change never needed to touch, and every unrelated hunk is
+more for a reviewer to read and rule out.
 
 So before you open a pull request, whatever tools you used to get there:
 
-- Have you read every line you are about to submit?
+- Have you read every line you are about to submit, and do you understand what
+  each one does and why it is there?
 - Have you run it, and does your test actually fail without the change?
-- Can you defend each decision in review, in your own words?
-- Is it free of code, comments, or documentation that is not relevant to the
-  change?
-
-If the answer to all four is yes, we genuinely do not care how you got there.
+- Is the diff limited to what the change requires?
 
 (sec:contributing-code)=
 ## Contributing Code

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -1,226 +1,408 @@
 # Contributing to Fandango
 
-Welcome!
-Fandango is a community project that aims to work for a wide
-range of developers.
-If you're trying out Fandango, your experience and what you can contribute are
-important to the project's success.
+Welcome! Fandango is a community project that aims to work for a wide range of
+developers. If you are trying out Fandango, your experience and what you can
+contribute are important to the project's success.
+
+This page covers everything from reporting a bug to getting a pull request
+merged. If you only want to *use* Fandango, see [Installing](sec:installing)
+instead.
 
 (sec:code-of-conduct)=
 ## Code of Conduct
 
-Everyone participating in Fandango, and in particular in our
-issue tracker, pull requests, and chat, is expected to treat
-other people with respect and more generally to follow the guidelines
-articulated in the [Python Community Code of Conduct](https://www.python.org/psf/codeofconduct/).
+Everyone participating in Fandango, and in particular in our issue tracker,
+pull requests, and chat, is expected to treat other people with respect and to
+follow the [Python Community Code of
+Conduct](https://www.python.org/psf/codeofconduct/).
+
+If you experience or witness unacceptable behaviour, report it to
+[fandango-fuzzer@protonmail.com](mailto:fandango-fuzzer@protonmail.com). Reports
+are handled confidentially. See
+[`CODE_OF_CONDUCT.md`](https://github.com/fandango-fuzzer/fandango/blob/main/CODE_OF_CONDUCT.md)
+in the repository root.
+
+(sec:ways-to-contribute)=
+## Ways to Contribute
+
+You do not have to write code to help.
+
+* **Report a bug.** See [reporting bugs](sec:reporting-bugs) below.
+* **Request a feature**, or tell us where Fandango was confusing to use.
+* **Improve the documentation.** This book is part of the repository, and doc
+  fixes are among the most useful contributions we get.
+* **Fix an issue.** Browse the [issue
+  tracker](https://github.com/fandango-fuzzer/fandango/issues) and pick
+  something up.
+
+For security vulnerabilities, do **not** open a public issue. Report them
+privately through GitHub's [security advisory form](https://github.com/fandango-fuzzer/fandango/security/advisories/new), reachable from the
+repository's Security tab, so the report, the fix, and the advisory stay in one
+private thread. See
+[`SECURITY.md`](https://github.com/fandango-fuzzer/fandango/blob/main/SECURITY.md).
+
+(sec:reporting-bugs)=
+## Reporting Bugs
+
+A good report is one someone else can reproduce. Please include:
+
+* **What you did**: the `.fan` spec (reduced to the smallest one that still
+  shows the problem) and the exact command you ran.
+* **What you expected** to happen, and **what happened instead**, including the
+  full error message and traceback.
+* **Your environment**: the output of `fandango --version`, your Python version,
+  and your operating system.
+
+A spec that is a hundred lines long makes a bug much harder to act on than one
+that is five. Time spent reducing the input is usually time saved overall.
+
+(sec:first-time-contributors)=
+## First Time Contributors
+
+If you are not yet fluent in Fandango's specification language, the fastest way
+in is the [hands-on tutorial](sec:handson). It builds one small protocol from
+random bytes up to a stateful conversation, and by the end you will have written
+the grammars, constraints, and feedback that most issues are about. It takes an
+afternoon and it is the same material we would otherwise explain in review.
+
+If you are looking for something to work on, browse the [issue
+tracker](https://github.com/fandango-fuzzer/fandango/issues).
+
+**Check whether the issue is assigned before you start.** If it already has an
+assignee, someone is working on it, so please pick a different one. Duplicated
+effort is wasted effort, and it is discouraging for whoever got there first.
+
+**If it is unassigned, say so in the issue before you begin**, and wait to be
+assigned. A short comment is enough. This is not bureaucracy: it lets us tell
+you if the issue is more involved than it looks, if it is already being
+addressed elsewhere, or if we have a view on the approach. All of that is much
+cheaper to hear before you write the code than after.
+
+Once the issue is yours, fix it, [add a test](sec:running-tests), and open a
+pull request.
+
+To get help with a specific issue, comment on the issue itself, and say what you
+have already tried and where you have looked. If you find you cannot finish
+something you claimed, just say so in the issue and unassign yourself. That is
+completely fine and much better than an issue going quiet.
+
+If your change is going to be a significant amount of work, open an issue first
+describing what you intend to do. That way a conversation can happen early,
+before you have written code that someone disagrees with.
 
 (sec:getting-started-with-development)=
-## Getting Started with Development
+## Setting Up a Development Environment
 
-### Step 1: Fork the Fandango repository
+Fandango requires **Python 3.11 or later**. Our CI tests against Python 3.11,
+3.12, 3.13, and 3.14 on Linux, macOS, and Windows.
 
-Within GitHub, navigate to the [Fandango GitHub repository](https://github.com/fandango-fuzzer/fandango) and fork the repository.
+### Step 1: Fork and clone
 
-
-### Step 2: Clone the Fandango repository and enter into it
-
-```shell
-$ git clone https://github.com/fandango-fuzzer/fandango.git
-```
+Fork the [Fandango repository](https://github.com/fandango-fuzzer/fandango) on
+GitHub, then clone your fork:
 
 ```shell
+$ git clone https://github.com/YOUR-USERNAME/fandango.git
 $ cd fandango
 ```
 
-### Step 3: Create, then activate a virtual environment
+### Step 2: Install the system tools
 
-```shell
-$ python3 -m venv .venv
-```
-
-```shell
-$ source .venv/bin/activate
-```
-
-For Windows, use
-```shell
-$ python -m venv .venv
-```
-
-```shell
-$ . venv/Scripts/activate
-```
-
-For more details, see https://docs.python.org/3/library/venv.html#creating-virtual-environments
-
-
-### Step 4: Install development tools
-
-Install `antlr` and other system-level tools:
+Fandango's parser is generated with ANTLR and compiled with a C++ compiler.
+Install both:
 
 ```shell
 $ make system-dev-tools
 ```
 
+```{note}
+This installs system packages (via Homebrew, apt, or Chocolatey depending on
+your platform), so it may ask for your password.
+```
+
+(sec:uv-install)=
+### Step 3: Install Fandango with `uv`
+
+We recommend [uv](https://docs.astral.sh/uv/). It creates the virtual
+environment and installs the exact dependency set our CI uses, taken from
+`uv.lock`:
+
+```shell
+$ uv sync --all-extras --locked
+```
+
+That is the whole setup. Run Fandango with `uv run fandango`, or activate the
+environment it created:
+
+```shell
+$ source .venv/bin/activate
+```
+
+On Windows, use `.venv\Scripts\activate`.
+
+```{tip}
+Because `--locked` pins every dependency to the versions our CI resolved, this
+is also the fastest way to rule out a dependency problem when something behaves
+differently for you than for us.
+```
+
 (sec:pip-install)=
-### Step 5: Install Fandango
-ti
-Install your local copy of Fandango:
+### Step 3, alternative: Install with `pip`
+
+If you would rather not use `uv`, create a virtual environment and install
+Fandango into it as an editable package:
 
 ```shell
-$ python -m pip install -e .
+$ python3 -m venv .venv
+$ source .venv/bin/activate
+$ python -m pip install -e ".[full]"
 ```
 
-To install additional dependencies for unit tests, code checks, running the evaluation, and building the Fandango book, install Fandango like this (or with the subsection of dependencies you need):
+On Windows, create and activate the environment with:
 
 ```shell
-$ python -m pip install -e ".[test,development,evaluation,book]"
+$ python -m venv .venv
+$ .venv\Scripts\activate
 ```
 
-:::{tip}
-If subsequent tests fails due to dependency breakage, use `uv` to create the virtual environment with `uv.lock`, which provides a snapshot of the dependencies that are tested on our CI:
+The `full` extra pulls in everything you need to develop: it is shorthand for
+`book`, `development`, and `test`. To install a subset instead, name the ones
+you want, for example `pip install -e ".[test]"`.
 
-```shell
-$ uv sync --locked --all-extras
-```
-:::
+| Extra | Gives you |
+|---|---|
+| `test` | the unit test suite and its fixtures |
+| `development` | Ruff, mypy, and the other code-quality tools |
+| `book` | everything needed to build this documentation |
+| `full` | all three of the above |
 
-
-If you don't need the (much faster) C++ parser, build Fandango without it:
-
-```shell
-$ FANDANGO_SKIP_CPP_PARSER=1 python -m pip install -e .
-```
-
-Reset the shell PATH cache (not necessary on Windows):
+Reset your shell's command lookup afterwards, so `fandango` resolves to your
+copy (not needed on Windows):
 
 ```shell
 $ hash -r
 ```
 
-That's it! You just have installed your personal copy of Fandango.
-You can invoke it as `fandango` and can alter its code as you like.
+### If the build fails
+
+The C++ parser is the usual culprit, because it needs ANTLR and a working C++
+toolchain. You can skip it entirely:
+
+```shell
+$ FANDANGO_SKIP_CPP_PARSER=1 uv sync --all-extras --locked
+```
+
+Fandango then falls back to the pure-Python parser. Everything still works and
+parsing is slower, which is fine for most development.
+
+```{note}
+`make system-dev-tools` is what installs the toolchain the C++ parser needs. If
+you skipped it in Step 2, that is the first thing to try.
+```
+
+That's it. You have installed your personal copy of Fandango, you can invoke it
+as `fandango`, and you can change its code as you like.
 
 (sec:running-tests)=
 ## Running Tests
 
-Running the full test suite can take a while, and usually is not necessary when
-preparing a pull request.
-Once you file a pull request, the full test suite will run on GitHub.
-You'll then be able to see any test failures, and make any necessary changes to
-your pull request.
+Running the full suite takes a while and is usually not necessary while
+preparing a pull request. Once you open one, the full suite runs on GitHub and
+you can fix anything it catches.
 
-However, if you wish to do so, you can run the full test suite
-like this:
+To run it yourself:
 
 ```shell
 $ make tests
 ```
 
-or simply
+or equivalently:
 
 ```shell
 $ pytest
 ```
 
-To run tests in parallel, you can use [pytest-xdist](https://pytest-xdist.readthedocs.io/en/stable/) (installed with the `test` dependencies):
+The suite runs in parallel by default via
+[pytest-xdist](https://pytest-xdist.readthedocs.io/en/stable/). To run a single
+test file while working on it:
 
 ```shell
-$ pytest -n auto
+$ pytest tests/test_some_file.py -x
 ```
 
-### Pre-commit
+```{warning}
+`make test` (singular) is not the test target and does nothing. Use `make
+tests`.
+```
 
-Fandango provides a config file for `pre-commit`. To install it, run the following:
+(sec:pre-commit)=
+## Pre-commit
+
+Fandango ships a `pre-commit` configuration that catches most of what CI checks,
+before you push:
 
 ```shell
 $ pip install pre-commit
 $ pre-commit install
 ```
 
-This will run code formatting, linting with Ruff, and type checking before every commit.
+The hooks run Ruff formatting, Ruff linting, mypy (including `--strict` on
+`src`), and the lockfile checks described below.
 
 ```{warning}
-The [tests](sec:running-tests) are not run as part of pre-commit, because they take significant time to complete. Run them manually.
+The [tests](sec:running-tests) are not part of pre-commit, because they take
+too long. Run them yourself.
 ```
 
-To support reproducible environments and compatibility across a wider range of tools in the Python ecosystem, we keep both `uv.lock` and `pylock.toml` up to date. 
+(sec:ci-checks)=
+## What CI Checks
 
-- `uv.lock` is the lockfile generated by `uv` and captures the actual dependency set used in this project (i.e., source of truth). Update with `uv lock`
-- `pylock.toml` is derived from `uv.lock` to support a wider range of ecosystem tools. Update with `uv export --output-file=pylock.toml --all-extras --locked`.
+Every pull request runs the following. Knowing this list saves a round trip,
+since these are the things that most often turn a pull request red:
 
-After updating dependencies in `pyproject.toml`, make sure to regenerate `uv.lock` and `pylock.toml` to keep them up to date, e.g. by running `make lock`. Both pre-commit hooks and the CI pipeline contain checks for these.
+| Check | Command | Scope |
+|---|---|---|
+| Formatting | `ruff format --check .` | the **whole repository**, not just `src` |
+| Linting | `ruff check src tests evaluation scripts` | those four directories |
+| Types | `mypy .` and `mypy --strict src` | the whole repository, then `src` strictly |
+| Tests | `pytest` | Python 3.11 to 3.14, on Linux, macOS, and Windows |
+| Docs | `make web` | the whole book must build |
+| Lockfiles | `uv lock --check` and a `pylock.toml` diff | see below |
 
-(sec:first-time-contributors)=
-## First Time Contributors
+The formatting and type checks cover the entire repository, so a stray file
+outside `src` can fail the build. Running `pre-commit` locally catches almost
+all of it.
 
-If you're looking for things to help with, browse our [issue tracker](https://github.com/fandango-fuzzer/fandango/issues)!
+(sec:lockfiles)=
+### Lockfiles
 
-You do not need to ask for permission to work on any of these issues.
-Just fix the issue yourself, [try to add a unit test](sec:running-tests) and open a pull request.
+We keep both lockfiles current, for reproducible environments and for
+compatibility with the wider Python ecosystem:
 
-To get help fixing a specific issue, it's often best to comment on the issue itself.
-You're much more likely to get help if you provide details about what you've tried and where you've looked (maintainers tend to help those who help themselves).
+* `uv.lock` is generated by `uv` and is the source of truth for the dependency
+  set. Update it with `uv lock`.
+* `pylock.toml` is derived from `uv.lock` so that other tools can consume it.
+  Update it with `uv export --output-file=pylock.toml --all-extras --locked`.
 
+After changing dependencies in `pyproject.toml`, regenerate both:
+
+```shell
+$ make lock
+```
+
+Both pre-commit and CI check that these are in sync, so forgetting this step
+fails the build.
+
+(sec:ai-assistance)=
+## Using AI Assistance
+
+We are not against AI tools and we do not ask you to declare that you used one.
+Plenty of good contributions are written with a model in the loop, and we use
+them ourselves.
+
+What we do require is that **you own the code you submit**. You should be able
+to explain why the change is written the way it is, why it is correct, what
+alternatives you rejected, and what happens at the edges. If a reviewer asks
+about a decision and the honest answer would be "the model wrote it that way",
+the pull request is not ready to open.
+
+The problem we care about is not AI. It is **moving your work onto the
+maintainers**. A patch produced by pasting an issue into a model and pushing the
+result, without reading it, running it, or understanding it, costs us more time
+than the issue would have. Reviewing that means reconstructing an intent that
+was never formed in the first place, which is harder than writing the fix from
+scratch. That is not a contribution, it is a transfer of effort.
+
+This is usually easy to spot. Pull requests that look this way will be
+inspected closely, and if it turns out the work has been handed to us rather
+than done, we will close them without merging.
+
+So before you open a pull request, whatever tools you used to get there:
+
+- Have you read every line you are about to submit?
+- Have you run it, and does your test actually fail without the change?
+- Can you defend each decision in review, in your own words?
+- Is it free of code, comments, or documentation that is not relevant to the
+  change?
+
+If the answer to all four is yes, we genuinely do not care how you got there.
 
 (sec:contributing-code)=
 ## Contributing Code
 
-Even more excellent than a good bug report is a fix for a bug, or the implementation of a much-needed new feature.
-We'd love to have your contributions.
+We use the usual GitHub pull request flow. If it is unfamiliar, see [GitHub's
+documentation](https://docs.github.com/en/pull-requests).
 
-We use the usual GitHub pull-request flow, which may be familiar to you if you've contributed to other projects on GitHub.
-For the mechanics, see [GitHub's own documentation](https://help.github.com/articles/using-pull-requests/).
+Anyone interested in Fandango may review your code, and one of the core
+developers merges it when they think it is ready.
 
-Anyone interested in Fandango may review your code.
-One of the Fandango core developers will merge your pull request when they think it's ready.
+**What makes a pull request easy to merge:**
 
-If your change will be a significant amount of work to write, we highly recommend starting by opening an issue laying out
-what you want to do.
-That lets a conversation happen early in case other contributors disagree with what you'd like to do or have ideas that will help you do it.
+* It does **one thing**. A focused change is far easier to review than a large
+  one, and reviewability is usually what decides how fast something lands.
+* It says **what** it changes and **why**. The why matters more; the diff
+  already shows the what.
+* It comes with **tests** for any behaviour it changes. A regression test that
+  fails before your fix and passes after is the most convincing thing you can
+  include.
+* It **updates the documentation** when it changes something a user can see.
+* It is **green in CI**.
 
-The best pull requests are focused, clearly describe what they're for and why they're correct, and contain tests for whatever changes they make to the code's behavior.
-As a bonus these are easiest for someone to review, which helps your pull request get merged quickly!
-Standard advice about good pull requests for open-source projects applies.
+If a review asks for changes, push additional commits to the same branch rather
+than force-pushing a rewritten history. That keeps the review comments anchored
+to the code they refer to.
 
+Pull requests are merged with a merge commit, so the commits on your branch stay
+in the project history. They do not need to be perfect, but a reader six months
+from now benefits from commit messages that say what changed and why.
 
-### Changing Parser Files
+(sec:contribution-licensing)=
+### Licensing of Contributions
 
-If your contribution involves changing the ANTLR `.g4` parser files,
-you need to _regenerate_ and _recompile_ the parser code.
-For this, you need a C++ compiler such as `clang`.
+Fandango is released under the [European Union Public Licence v1.2](https://github.com/fandango-fuzzer/fandango/blob/main/LICENSE.md).
+By contributing, you agree that your contribution is licensed under those same
+terms, and you confirm that you have the right to submit it.
 
-#### Step 1: Generate the parser code
+### Changing the Parser
 
-To (re)generate the parser code, use
+If your contribution changes the ANTLR `.g4` files, you have to regenerate and
+recompile the parser. This needs a C++ compiler such as `clang`.
+
+Regenerate the parser code:
 
 ```shell
 $ make parser
 ```
 
-#### Step 2: Compile the parser code
-
-The `pip` command takes care of (re)compiling the parser code.
-Simply [reinstall Fandango](sec:pip-install).
+Then reinstall Fandango, which recompiles it: see [installing with
+uv](sec:uv-install) or [with pip](sec:pip-install).
 
 ```{note}
-If compiling the C++ code for parsing fails,
-Fandango uses (slower) Python code instead.
+If compiling the C++ parser fails, Fandango falls back to the slower Python
+parser, so this is not a hard blocker for testing your change.
 ```
 
+### Contributing to the Documentation
 
-### Contributing to Documentation
-
-If you want to contribute to this very tutorial and reference, be sure to preview your changes.
-Use
+This book lives in `docs/` in the repository. Preview your changes before
+opening a pull request:
 
 ```shell
 $ make html
 ```
 
-to create an HTML version of the documentation in `docs/_build/html`.
+The result lands in `docs/_build/html`. Because CI builds the book on every
+pull request, a broken directive or a dead cross-reference fails the build, so
+it is worth checking locally.
 
+```{tip}
+The book executes many of its own code examples while building. If your change
+touches an executed example, build the book to confirm the output is still what
+the page claims.
+```
 
 ## Attributions
 
-This guide was forked from the [mypy contribution guide](https://github.com/python/mypy/blob/master/CONTRIBUTING.md), which is licensed under the terms of the MIT license.
+This guide was originally forked from the [mypy contribution
+guide](https://github.com/python/mypy/blob/master/CONTRIBUTING.md), which is
+licensed under the terms of the MIT license.


### PR DESCRIPTION
The contributing guide had drifted from the repository, and most of the files GitHub expects a project to have were missing.

## What was broken

Three instructions in `docs/Contributing.md` did not work:

- it told you to install a **`evaluation` extra that does not exist** (the real ones are `book`, `development`, `full`, `test`, and `full` was never mentioned),
- the Windows activation path was `. venv/Scripts/activate`, missing a dot,
- a stray `ti` sat on its own line in the middle of the install steps.

Structurally, the reliable path was buried. Steps 3 to 5 walked you through `venv` plus `pip install -e .`, while CI uses `uv sync --all-extras --locked` and we maintain `uv.lock` as the source of truth. `uv` appeared only in a tip beginning "If subsequent tests fail due to dependency breakage". The guide also never stated which Python versions we support.

## The guide, rewritten

- **uv first**, matching CI exactly, with pip kept as a genuine alternative and the C++ parser fallback (`FANDANGO_SKIP_CPP_PARSER=1`) documented where you hit it
- **a table of what CI checks.** Formatting and types run over the whole repository, not just `src`, which is the most common reason a pull request goes red
- **how to report a bug**, how the lockfiles are regenerated, and what makes a pull request easy to review
- **issues are claimed before work starts.** If an issue is assigned, leave it. If it is not, ask in the issue and wait to be assigned. The old text said the opposite
- **a section on AI assistance.** No objection to the tools. The requirement is that you own what you submit and can explain it in review, because a patch nobody has read costs more to review than the issue costs to fix
- contributions are licensed under **EUPL-1.2**, same as the project

## New files

| File | Why |
|---|---|
| `CONTRIBUTING.md` | root copy, which is what GitHub actually surfaces on a new PR or issue |
| `CODE_OF_CONDUCT.md` | the guide cited a code of conduct with no file behind it and no way to report a violation |
| `SUPPORT.md` | routes usage questions away from the bug tracker |
| `CITATION.cff` | GitHub can now offer the ISSTA 2025 paper, validated against the CFF 1.2.0 schema |
| `.editorconfig` | matches the Ruff settings, tabs for `Makefile` |
| `.github/PULL_REQUEST_TEMPLATE.md` | |
| `.github/ISSUE_TEMPLATE/` | bug report, feature request, and a config routing security reports away from public issues |

## Security policy

`SECURITY.md` now routes reports through GitHub's **private advisory form** rather than a shared mailbox, so the report, our questions, the fix, and the advisory stay in one private thread, and we can request a CVE and credit the reporter from it. The mailbox survives as a fallback, with a note not to put exploit details in a first email.

It also gains response times and a **scope** section. Fandango executes the specifications it is given, by design, so running an untrusted spec is not a vulnerability. Saying that up front is easier than arguing it case by case.

## README

Gains an install command, which it did not have at all, plus links to the guide, the code of conduct, support, the security policy, the hands-on tutorial, and how to cite.

## Checks

Every command and extra in the new guide was verified against the Makefile and `pyproject.toml`. All documentation links resolve, `CITATION.cff` validates against the CFF schema, the issue templates parse, and the book builds.