### PR TITLE
Bump to 1.2 and write the release notes

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,6 +9,7 @@ abstract: >-
   grammar with constraints written in Python, Fandango generates myriads of
   valid inputs using an evolutionary search.
 type: software
+version: 1.2.0
 license: EUPL-1.2
 repository-code: https://github.com/fandango-fuzzer/fandango
 url: https://fandango-fuzzer.github.io/

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -1,3 +1,4 @@
+(sec:contributing)=
 # Contributing to Fandango
 
 Welcome! Fandango is a community project that aims to work for a wide range of

--- a/docs/Diversity.md
+++ b/docs/Diversity.md
@@ -32,18 +32,30 @@ During [_protocol testing_](sec:protocols), Fandango already produces such inter
 
 Grammar coverage is determined and achieved using the $k$-path metric by {cite:ts}`havrikov2019ase`.
 
-```{versionadded} 1.2
-For version 1.2, during input generation, Fandango will also achieve grammar coverage by construction.
+```{versionadded} 1.x
+In a future version, during input generation, Fandango will also achieve grammar coverage by construction.
 ```
 
 
+(sec:code-coverage)=
 ## Code Coverage
 
-As of version 1.2, Fandango will provide experimental support for guidance by code coverage.
-Details will be added here.
+As of version 1.2, Fandango provides _experimental_ support for guidance by code coverage.
+It works against a program under test that has been compiled with [`fcc`](https://github.com/fandango-fuzzer/fcc), the Fandango coverage compiler.
+`fcc` records the control flow graph of the program at compile time; at run time, Fandango tracks which basic blocks each input reaches, and favors inputs that get closer to code it has not seen yet.
+
+```shell
+$ fandango --enable-experimental-module execution fuzz -f spec.fan --fcc ./program
+```
+
+```{warning}
+This is an experimental feature, living in `fandango.experimental.execution`.
+It may change without notice, so do not rely on it in production.
+Fandango warns you about this the first time the module is loaded; `--enable-experimental-module execution` is how you acknowledge the warning and silence it.
+```
 
 ```{versionadded} 1.2
-This feature is planned for Fandango 1.2.
+Experimental code coverage guidance is available in Fandango 1.2 and later.
 ```
 
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -15,13 +15,41 @@ kernelspec:
 
 This document lists major changes across releases.
 
+```{versionadded} 1.2 (August 2026)
+* Grammars gained a **permutation operator**: `[[ <a> <b> <c> ]]` produces and parses the enclosed symbols in any order. It works for protocol messages too, so a spec can state that two packets may arrive in either order.
+* **Timers for protocol testing.** A spec can now start and cancel timers and react to them expiring, so interactions that hinge on timeouts can be tested.
+* Two new ways to stop a fuzzing run once it has done its job:
+   * `--stop-criterion` takes a Python lambda that is evaluated on every new solution, for instance `--stop-criterion 'lambda t: t.to_string().startswith("abc")'`.
+   * `--stop-after-seconds` stops at the start of the first generation after the given number of seconds.
+* Experimental support for [guidance by code coverage](sec:code-coverage). Against a program compiled with [`fcc`](https://github.com/fandango-fuzzer/fcc), `fandango fuzz --fcc` steers input generation towards code that has not been reached yet.
+* Submodules under `fandango.experimental.*` are now marked as experimental: they can change without notice, and importing one emits a warning. `--enable-experimental-module MODULE` opts you in to a module and silences its warning.
+* Internal caches are now bounded, so long runs no longer grow without limit. Set their size with the `FANDANGO_CACHE_SIZE` environment variable.
+* `--format=1` prints the constant `1` for every output, which is useful for testing.
+* New `DerivationTree.find_subtrees()`, which also accepts a symbol name as a plain string. It replaces `find_all_trees()`.
+* Further improved [protocol fuzzing](sec:protocols): a dedicated protocol algorithm, $k$-path coverage tracking of the interactions produced so far, and a packet selector that plans which message to send next.
+* We have added new [PNG](sec:png) and [MP3](sec:mp3) case studies.
+* New [hands-on tutorial](sec:handson), which builds one protocol from random bytes up to a stateful conversation.
+* New [style guide](sec:style) for writing specs that are reusable, extensible, and efficient.
+* Lots of minor bug fixes.
+* [development] Python 3.14 is now supported, and tested in CI alongside 3.11, 3.12, and 3.13.
+* [development] Fandango now builds with `scikit-build-core` alone, and `setup.py` is gone. Set `FANDANGO_SKIP_CPP_PARSER=1` to skip the C++ parser, or `FANDANGO_REQUIRE_BINARY_BUILD=1` to insist on it.
+* [development] We now ship a `pylock.toml` next to `uv.lock`, so tools other than `uv` can consume our dependency set.
+* [development] Ruff replaces black for formatting and linting.
+* [development] The project now has a [contribution guide](sec:contributing), a code of conduct, a support policy, a security policy, issue and pull request templates, and a `CITATION.cff`.
+```
+
+```{versionchanged} 1.2
+* Fandango now requires **Python 3.11 or later**. Python 3.10 is no longer supported.
+* `DerivationTree.find_all_trees()` is deprecated. Use `find_subtrees()` instead.
+```
+
 ```{versionadded} 1.1 (February 2026)
 * Much enhanced [protocol fuzzing](sec:protocols):
    * Protocol fuzzing is now out of beta.
    * `fandango talk` now keeps on producing diverse interactions, systematically covering states and messages until stopped or 100% coverage is reached.
    * Detailed documentation with [FTP](sec:ftp) and [DNS](sec:dns) case studies.
    * `fandango convert` can now produce [state diagrams from grammars](sec:extracting-state-diagrams).
-* We have added new [PNG](sec:png), [GIF](sec:gif), and [MP3](sec:mp3) case studies.
+* We have added a new [GIF](sec:gif) case study.
 * You can now [download the **documentation** as a PDF](_static/fandango.pdf) from the upper-right download icon.
 * Lots of minor bug fixes.
 * [development] Major internal refactorings and code quality improvements.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -46,7 +46,7 @@ parse:
 html:
   use_issues_button: true
   use_repository_button: true
-  announcement: "<a href=\"https://pypi.org/project/fandango-fuzzer/1.1.1/\" style=\"color:white;\">Fandango 1.1.1</a> is now available! Check out the <a href=\"https://fandango-fuzzer.github.io/ReleaseNotes.html#\" style=\"color:white;\">release notes</a> for details."
+  announcement: "<a href=\"https://pypi.org/project/fandango-fuzzer/1.2.0/\" style=\"color:white;\">Fandango 1.2</a> is now available! Check out the <a href=\"https://fandango-fuzzer.github.io/ReleaseNotes.html#\" style=\"color:white;\">release notes</a> for details."
 
 repository:
   url: "https://github.com/fandango-fuzzer/fandango"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ wheel.cmake = true
 
 [project]
 name = "fandango-fuzzer"
-version = "1.1.1"
+version = "1.2.0"
 authors = [
     { name = "José Antonio Zamudio Amaya", email = "jose.zamudio@cispa.de" },
     { name = "Marius Smytzek", email = "marius.smytzek@cispa.de" },

--- a/src/fandango/cli/parser.py
+++ b/src/fandango/cli/parser.py
@@ -169,7 +169,7 @@ def _get_main_parser(in_command_line: bool) -> argparse.ArgumentParser:
             "--enable-experimental-module",
             dest="enable_experimental_modules",
             type=str,
-            help="Enable warnings about experimental modules. Can be given multiple times. Example: --enable-experimental-module execution",
+            help="Opt in to an experimental module, silencing its warning. Can be given multiple times. Example: --enable-experimental-module execution",
             default=[],
             action="append",
         )

--- a/tutorial/requirements.txt
+++ b/tutorial/requirements.txt
@@ -1,3 +1,3 @@
 # The only dependency for the whole tutorial. The target program (fdp.py) and
 # all helper scripts use the Python standard library only.
-fandango-fuzzer>=1.1.1
+fandango-fuzzer>=1.2.0

--- a/uv.lock
+++ b/uv.lock
@@ -809,7 +809,7 @@ wheels = [
 
 [[package]]
 name = "fandango-fuzzer"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "ansi-styles" },


### PR DESCRIPTION
Version 1.1.1 -> 1.2.0 in pyproject.toml, uv.lock, the book announcement banner, the tutorial requirement, and CITATION.cff.

The 1.2 notes cover the permutation operator, protocol timers, the two stop options, experimental code coverage guidance via fcc, the experimental module marking, bounded caches, --format=1, find_subtrees, the protocol engine work, and the new PNG, MP3, hands-on, and style chapters.

Two corrections along the way. The PNG and MP3 case studies were listed under 1.1 but only landed after v1.1.1, so they move to 1.2. The Code Coverage section of Diversity said the feature was planned for 1.2; it shipped, so it now describes how to use it, while grammar coverage by construction, which did not ship, moves to 1.x.

The --enable-experimental-module help said it enables warnings. It silences them, so the help now says that.