### PR TITLE
Grammars with unbreakable loops now cause an error instead of letting Fandango being stuck in an infinite recursion

### DIFF
--- a/src/fandango/language/grammar/grammar.py
+++ b/src/fandango/language/grammar/grammar.py
@@ -16,6 +16,7 @@ from fandango.language.grammar.has_settings import HasSettings
 from fandango.language.grammar.literal_generator import LiteralGenerator
 from fandango.language.grammar.node_visitors.disambiguator import Disambiguator
 from fandango.language.grammar.node_visitors.node_visitor import NodeVisitor
+from fandango.language.grammar.node_visitors.primer import PrimerVisitor
 from fandango.language.grammar.nodes.alternative import Alternative
 from fandango.language.grammar.nodes.char_set import CharSet
 from fandango.language.grammar.nodes.concatenation import Concatenation
@@ -912,46 +913,12 @@ class Grammar(NodeVisitor[list[Node], list[Node]]):
 
     def prime(self) -> None:
         LOGGER.debug("Priming grammar")
-        nodes: list[Node] = sum(
-            [self.visit(self.rules[symbol]) for symbol in self.rules], []
-        )
-        while nodes:
-            node = nodes.pop(0)
-            if isinstance(node, TerminalNode):
-                continue
-            elif isinstance(node, NonTerminalNode):
-                if node.symbol not in self.rules:
-                    raise FandangoValueError(
-                        f"Symbol {node.symbol.format_as_spec()} not found in grammar"
-                    )
-                if self.rules[node.symbol].distance_to_completion == float("inf"):
-                    nodes.append(node)
-                else:
-                    node.distance_to_completion = (
-                        self.rules[node.symbol].distance_to_completion + 1
-                    )
-            elif isinstance(node, Alternative):
-                node.distance_to_completion = (
-                    min([n.distance_to_completion for n in node.alternatives]) + 1
-                )
-                if node.distance_to_completion == float("inf"):
-                    nodes.append(node)
-            elif isinstance(node, Concatenation):
-                if any([n.distance_to_completion == float("inf") for n in node.nodes]):
-                    nodes.append(node)
-                else:
-                    node.distance_to_completion = (
-                        sum([n.distance_to_completion for n in node.nodes]) + 1
-                    )
-            elif isinstance(node, Repetition):
-                if node.node.distance_to_completion == float("inf"):
-                    nodes.append(node)
-                else:
-                    node.distance_to_completion = (
-                        node.node.distance_to_completion * node.min + 1
-                    )
-            else:
-                raise FandangoValueError(f"Unknown node type {node.node_type}")
+        primer = PrimerVisitor(self.rules)
+        primer.prime()
+        if primer.inf_loops:
+            raise FandangoValueError(
+                f"Grammar contains infinite loops: {primer.inf_loops}"
+            )
 
     def default_result(self) -> list[Node]:
         return []

--- a/src/fandango/language/grammar/grammar.py
+++ b/src/fandango/language/grammar/grammar.py
@@ -917,7 +917,7 @@ class Grammar(NodeVisitor[list[Node], list[Node]]):
         primer.prime()
         if primer.inf_loops:
             raise FandangoValueError(
-                f"Grammar contains infinite loops: {primer.inf_loops}"
+                f"Grammar contains unbreakable, infinite loops: {primer.inf_loops}"
             )
 
     def default_result(self) -> list[Node]:

--- a/src/fandango/language/grammar/grammar.py
+++ b/src/fandango/language/grammar/grammar.py
@@ -915,10 +915,6 @@ class Grammar(NodeVisitor[list[Node], list[Node]]):
         LOGGER.debug("Priming grammar")
         primer = PrimerVisitor(self.rules)
         primer.prime()
-        if primer.inf_loops:
-            raise FandangoValueError(
-                f"Grammar contains unbreakable, infinite loops: {primer.inf_loops}"
-            )
 
     def default_result(self) -> list[Node]:
         return []

--- a/src/fandango/language/grammar/node_visitors/primer.py
+++ b/src/fandango/language/grammar/node_visitors/primer.py
@@ -85,7 +85,7 @@ class PrimerVisitor(NodeVisitor[float, float]):
         return self.visitRepetition(node)
 
     def visitNonTerminalNode(self, node: NonTerminalNode) -> float:
-        return self.visit(self._rules[node.symbol]) + 1
+        return 1 + self.visit(self._rules[node.symbol])
 
     def visitTerminalNode(self, node: TerminalNode) -> float:
         return 1.0

--- a/src/fandango/language/grammar/node_visitors/primer.py
+++ b/src/fandango/language/grammar/node_visitors/primer.py
@@ -1,0 +1,76 @@
+from fandango.language.grammar.node_visitors.node_visitor import (
+    NodeVisitor,
+    ResultType,
+)
+from fandango.language.grammar.nodes.alternative import Alternative
+from fandango.language.grammar.nodes.char_set import CharSet
+from fandango.language.grammar.nodes.concatenation import Concatenation
+from fandango.language.grammar.nodes.node import Node
+from fandango.language.grammar.nodes.non_terminal import NonTerminalNode
+from fandango.language.grammar.nodes.repetition import Option, Plus, Repetition, Star
+from fandango.language.grammar.nodes.terminal import TerminalNode
+from fandango.language.symbols.non_terminal import NonTerminal
+from fandango.language.symbols.symbol import Symbol
+
+
+class PrimerVisitor(NodeVisitor):
+
+    def __init__(self, rules: dict[NonTerminal, Node]):
+        self._rules = rules
+        self._seen_count: dict[Node, int] = dict()
+        self.inf_loops: set[Node] = set()
+
+    def prime(self):
+        self._seen_count.clear()
+        self.inf_loops.clear()
+        for rule in self._rules.values():
+            self.visit(rule)
+        self.inf_loops = {n for n in self.inf_loops if n.distance_to_completion == float('inf')}
+
+    def visit(self, node: Node) -> ResultType:
+        seen_count = self._seen_count.get(node, 0)
+        if seen_count > 1:
+            return float('inf')
+        self._seen_count[node] = seen_count + 1
+        dist = super().visit(node)
+        node.distance_to_completion = dist
+        if dist == float('inf'):
+            self.inf_loops.add(node)
+        self._seen_count[node] = self._seen_count.get(node, 0) - 1
+        return dist
+
+    def visitAlternative(self, node: Alternative) -> ResultType:
+        minimal_dist = float('inf')
+        for child in node.children():
+            child_dist = self.visit(child)
+            if minimal_dist > child_dist:
+                minimal_dist = child_dist
+        return minimal_dist + 1
+
+    def visitConcatenation(self, node: Concatenation) -> ResultType:
+        total_dist = 0
+        for child in node.children():
+            total_dist += self.visit(child)
+        return total_dist + 1
+
+    def visitRepetition(self, node: Repetition) -> ResultType:
+        child_dist = self.visit(node.node)
+        return child_dist + 1
+
+    def visitStar(self, node: Star) -> ResultType:
+        return self.visitRepetition(node)
+
+    def visitPlus(self, node: Plus) -> ResultType:
+        return self.visitRepetition(node)
+
+    def visitOption(self, node: Option) -> ResultType:
+        return self.visitRepetition(node)
+
+    def visitNonTerminalNode(self, node: NonTerminalNode) -> ResultType:
+        return self.visit(self._rules[node.symbol])
+
+    def visitTerminalNode(self, node: TerminalNode) -> ResultType:
+        return 1
+
+    def visitCharSet(self, node: CharSet) -> ResultType:
+        raise NotImplementedError("ChatSet not implemented.")

--- a/src/fandango/language/grammar/node_visitors/primer.py
+++ b/src/fandango/language/grammar/node_visitors/primer.py
@@ -13,7 +13,6 @@ from fandango.language.symbols.non_terminal import NonTerminal
 
 
 class PrimerVisitor(NodeVisitor):
-
     def __init__(self, rules: dict[NonTerminal, Node]):
         self._rules = rules
         self._seen: set[int] = set()
@@ -30,7 +29,9 @@ class PrimerVisitor(NodeVisitor):
             self._changed = False
             for rule in self._rules.values():
                 self.visit(rule)
-        self.inf_loops = {n for n in self.inf_loops if n.distance_to_completion == float('inf')}
+        self.inf_loops = {
+            n for n in self.inf_loops if n.distance_to_completion == float("inf")
+        }
 
     def visit(self, node: Node) -> ResultType:
         if id(node) in self._seen:
@@ -40,13 +41,13 @@ class PrimerVisitor(NodeVisitor):
         if node.distance_to_completion > dist:
             self._changed = True
             node.distance_to_completion = dist
-        if dist == float('inf'):
+        if dist == float("inf"):
             self.inf_loops.add(node)
         self._seen.remove(id(node))
         return dist
 
     def visitAlternative(self, node: Alternative) -> ResultType:
-        minimal_dist = float('inf')
+        minimal_dist = float("inf")
         for child in node.children():
             child_dist = self.visit(child)
             if minimal_dist > child_dist:
@@ -61,6 +62,8 @@ class PrimerVisitor(NodeVisitor):
 
     def visitRepetition(self, node: Repetition) -> ResultType:
         child_dist = self.visit(node.node)
+        if node.min == 0:
+            return 1
         return (node.min * child_dist) + 1
 
     def visitStar(self, node: Star) -> ResultType:
@@ -73,7 +76,7 @@ class PrimerVisitor(NodeVisitor):
         return self.visitRepetition(node)
 
     def visitNonTerminalNode(self, node: NonTerminalNode) -> ResultType:
-        return self.visit(self._rules[node.symbol])
+        return self.visit(self._rules[node.symbol]) + 1
 
     def visitTerminalNode(self, node: TerminalNode) -> ResultType:
         return 1

--- a/src/fandango/language/grammar/node_visitors/primer.py
+++ b/src/fandango/language/grammar/node_visitors/primer.py
@@ -10,33 +10,39 @@ from fandango.language.grammar.nodes.non_terminal import NonTerminalNode
 from fandango.language.grammar.nodes.repetition import Option, Plus, Repetition, Star
 from fandango.language.grammar.nodes.terminal import TerminalNode
 from fandango.language.symbols.non_terminal import NonTerminal
-from fandango.language.symbols.symbol import Symbol
 
 
 class PrimerVisitor(NodeVisitor):
 
     def __init__(self, rules: dict[NonTerminal, Node]):
         self._rules = rules
-        self._seen_count: dict[Node, int] = dict()
+        self._seen: set[int] = set()
         self.inf_loops: set[Node] = set()
+        self._changed = False
 
     def prime(self):
-        self._seen_count.clear()
+        self._seen.clear()
         self.inf_loops.clear()
+        self._changed = False
         for rule in self._rules.values():
             self.visit(rule)
+        while self._changed:
+            self._changed = False
+            for rule in self._rules.values():
+                self.visit(rule)
         self.inf_loops = {n for n in self.inf_loops if n.distance_to_completion == float('inf')}
 
     def visit(self, node: Node) -> ResultType:
-        seen_count = self._seen_count.get(node, 0)
-        if seen_count > 1:
-            return float('inf')
-        self._seen_count[node] = seen_count + 1
+        if id(node) in self._seen:
+            return node.distance_to_completion
+        self._seen.add(id(node))
         dist = super().visit(node)
-        node.distance_to_completion = dist
+        if node.distance_to_completion > dist:
+            self._changed = True
+            node.distance_to_completion = dist
         if dist == float('inf'):
             self.inf_loops.add(node)
-        self._seen_count[node] = self._seen_count.get(node, 0) - 1
+        self._seen.remove(id(node))
         return dist
 
     def visitAlternative(self, node: Alternative) -> ResultType:

--- a/src/fandango/language/grammar/node_visitors/primer.py
+++ b/src/fandango/language/grammar/node_visitors/primer.py
@@ -1,7 +1,4 @@
-from fandango.language.grammar.node_visitors.node_visitor import (
-    NodeVisitor,
-    ResultType,
-)
+from fandango.language.grammar.node_visitors.node_visitor import NodeVisitor
 from fandango.language.grammar.nodes.alternative import Alternative
 from fandango.language.grammar.nodes.char_set import CharSet
 from fandango.language.grammar.nodes.concatenation import Concatenation
@@ -12,14 +9,14 @@ from fandango.language.grammar.nodes.terminal import TerminalNode
 from fandango.language.symbols.non_terminal import NonTerminal
 
 
-class PrimerVisitor(NodeVisitor):
+class PrimerVisitor(NodeVisitor[float, float]):
     def __init__(self, rules: dict[NonTerminal, Node]):
         self._rules = rules
         self._seen: set[int] = set()
         self.inf_loops: set[Node] = set()
         self._changed = False
 
-    def prime(self):
+    def prime(self) -> None:
         self._seen.clear()
         self.inf_loops.clear()
         self._changed = False
@@ -33,7 +30,7 @@ class PrimerVisitor(NodeVisitor):
             n for n in self.inf_loops if n.distance_to_completion == float("inf")
         }
 
-    def visit(self, node: Node) -> ResultType:
+    def visit(self, node: Node) -> float:
         if id(node) in self._seen:
             return node.distance_to_completion
         self._seen.add(id(node))
@@ -46,7 +43,7 @@ class PrimerVisitor(NodeVisitor):
         self._seen.remove(id(node))
         return dist
 
-    def visitAlternative(self, node: Alternative) -> ResultType:
+    def visitAlternative(self, node: Alternative) -> float:
         minimal_dist = float("inf")
         for child in node.children():
             child_dist = self.visit(child)
@@ -54,32 +51,32 @@ class PrimerVisitor(NodeVisitor):
                 minimal_dist = child_dist
         return minimal_dist + 1
 
-    def visitConcatenation(self, node: Concatenation) -> ResultType:
-        total_dist = 0
+    def visitConcatenation(self, node: Concatenation) -> float:
+        total_dist = 0.0
         for child in node.children():
             total_dist += self.visit(child)
         return total_dist + 1
 
-    def visitRepetition(self, node: Repetition) -> ResultType:
+    def visitRepetition(self, node: Repetition) -> float:
         child_dist = self.visit(node.node)
         if node.min == 0:
-            return 1
+            return 1.0
         return (node.min * child_dist) + 1
 
-    def visitStar(self, node: Star) -> ResultType:
+    def visitStar(self, node: Star) -> float:
         return self.visitRepetition(node)
 
-    def visitPlus(self, node: Plus) -> ResultType:
+    def visitPlus(self, node: Plus) -> float:
         return self.visitRepetition(node)
 
-    def visitOption(self, node: Option) -> ResultType:
+    def visitOption(self, node: Option) -> float:
         return self.visitRepetition(node)
 
-    def visitNonTerminalNode(self, node: NonTerminalNode) -> ResultType:
+    def visitNonTerminalNode(self, node: NonTerminalNode) -> float:
         return self.visit(self._rules[node.symbol]) + 1
 
-    def visitTerminalNode(self, node: TerminalNode) -> ResultType:
-        return 1
+    def visitTerminalNode(self, node: TerminalNode) -> float:
+        return 1.0
 
-    def visitCharSet(self, node: CharSet) -> ResultType:
+    def visitCharSet(self, node: CharSet) -> float:
         raise NotImplementedError("ChatSet not implemented.")

--- a/src/fandango/language/grammar/node_visitors/primer.py
+++ b/src/fandango/language/grammar/node_visitors/primer.py
@@ -72,7 +72,8 @@ class PrimerVisitor(NodeVisitor[float, float]):
         return 1 + sum(self.visit(child) for child in node.children())
 
     def visitRepetition(self, node: Repetition) -> float:
-        return 1 + (node.min * self.visit(node.node))
+        child_dist = self.visit(node.node)
+        return 1 + (node.min * child_dist)
 
     def visitStar(self, node: Star) -> float:
         return self.visitRepetition(node)

--- a/src/fandango/language/grammar/node_visitors/primer.py
+++ b/src/fandango/language/grammar/node_visitors/primer.py
@@ -61,7 +61,7 @@ class PrimerVisitor(NodeVisitor):
 
     def visitRepetition(self, node: Repetition) -> ResultType:
         child_dist = self.visit(node.node)
-        return child_dist + 1
+        return (node.min * child_dist) + 1
 
     def visitStar(self, node: Star) -> ResultType:
         return self.visitRepetition(node)

--- a/src/fandango/language/grammar/node_visitors/primer.py
+++ b/src/fandango/language/grammar/node_visitors/primer.py
@@ -1,3 +1,4 @@
+from fandango.errors import FandangoValueError
 from fandango.language.grammar.node_visitors.node_visitor import NodeVisitor
 from fandango.language.grammar.nodes.alternative import Alternative
 from fandango.language.grammar.nodes.char_set import CharSet
@@ -10,15 +11,28 @@ from fandango.language.symbols.non_terminal import NonTerminal
 
 
 class PrimerVisitor(NodeVisitor[float, float]):
+    """
+    Computes the `distance_to_completion` of every node reachable from a set of
+    grammar rules: the number of nodes to call to create the smallest possible subtree
+    derivable from that node.
+    """
+
     def __init__(self, rules: dict[NonTerminal, Node]):
         self._rules = rules
         self._seen: set[int] = set()
-        self.inf_loops: set[Node] = set()
+        self._inf_loops: set[Node] = set()
         self._changed = False
 
-    def prime(self) -> None:
+    def prime(self, raise_on_inf_loops: bool = True) -> None:
+        """
+        Sets the `distance_to_completion` attribute of every node reachable from the
+        rules.
+
+        :param raise_on_inf_loops: If there are NonTerminals in the grammar that cannot
+            be completed (distance_to_completion == float("inf")), raise a `FandangoValueError`.
+        """
         self._seen.clear()
-        self.inf_loops.clear()
+        self._inf_loops.clear()
         self._changed = False
         for rule in self._rules.values():
             self.visit(rule)
@@ -26,9 +40,17 @@ class PrimerVisitor(NodeVisitor[float, float]):
             self._changed = False
             for rule in self._rules.values():
                 self.visit(rule)
-        self.inf_loops = {
-            n for n in self.inf_loops if n.distance_to_completion == float("inf")
+        self._inf_loops = {
+            n for n in self._inf_loops if n.distance_to_completion == float("inf")
         }
+        if raise_on_inf_loops and self._inf_loops:
+            raise FandangoValueError(
+                f"Grammar contains unbreakable, infinite loops: {self._inf_loops}"
+            )
+
+    @property
+    def inf_loops(self) -> frozenset[Node]:
+        return frozenset(self._inf_loops)
 
     def visit(self, node: Node) -> float:
         if id(node) in self._seen:
@@ -39,29 +61,18 @@ class PrimerVisitor(NodeVisitor[float, float]):
             self._changed = True
             node.distance_to_completion = dist
         if dist == float("inf"):
-            self.inf_loops.add(node)
+            self._inf_loops.add(node)
         self._seen.remove(id(node))
         return dist
 
     def visitAlternative(self, node: Alternative) -> float:
-        minimal_dist = float("inf")
-        for child in node.children():
-            child_dist = self.visit(child)
-            if minimal_dist > child_dist:
-                minimal_dist = child_dist
-        return minimal_dist + 1
+        return 1 + min(self.visit(child) for child in node.children())
 
     def visitConcatenation(self, node: Concatenation) -> float:
-        total_dist = 0.0
-        for child in node.children():
-            total_dist += self.visit(child)
-        return total_dist + 1
+        return 1 + sum(self.visit(child) for child in node.children())
 
     def visitRepetition(self, node: Repetition) -> float:
-        child_dist = self.visit(node.node)
-        if node.min == 0:
-            return 1.0
-        return (node.min * child_dist) + 1
+        return 1 + (node.min * self.visit(node.node))
 
     def visitStar(self, node: Star) -> float:
         return self.visitRepetition(node)

--- a/tests/resources/infinite_loops.fan
+++ b/tests/resources/infinite_loops.fan
@@ -1,0 +1,32 @@
+# This grammar can't run. It contains a couple infinite, unbreakable loops for testing the primer here.
+# - <inf_simple> - simple unbreakable loop
+# - <inf_complex> - complex unbreakable loop
+# - <escapable> - escapable loops
+
+<start> ::= <inf_simple> | <inf_complex> | <escapable>
+
+
+# simple non-escapable loop
+<inf_simple> ::= "x" <inf_simple>
+
+
+# complex non-escapable loops
+<inf_complex> ::= <inf_a> | <inf_b> | <inf_c>
+<inf_a> ::= "<" <inf_b> ">" | <inf_c> <space> | <inf_b>{1,3}
+<inf_b> ::= <inf_c>{2,4} | <inf_a> <name>
+<inf_c> ::= <inf_a> | <inf_b> <inf_a> | "?" <inf_b>
+<space> ::= " "
+
+
+# escapable loops
+<escapable> ::= <expr>
+<expr> ::= <term> | <expr> "+" <term> | "-" <expr>
+<term> ::= <factor> | <term> "*" <factor>
+<factor> ::= <numeral> | "(" <expr> ")"
+
+
+# Non-loops
+<numeral> ::= <dig>+
+<dig> ::= "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+<name> ::= "fandango" | "is" | "awesome"
+

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -232,13 +232,16 @@ class PrimerTest(unittest.TestCase):
             grammar, _ = parse(file, use_stdlib=False, use_cache=False, check=False)
         assert grammar is not None
         primer = PrimerVisitor(grammar.rules)
-        primer.prime()
+        primer.prime(raise_on_inf_loops=False)
         return grammar, primer
 
     def test_error_on_parse(self):
         with self.assertRaises(FandangoValueError):
             with open(RESOURCES_ROOT / "infinite_loops.fan", "r") as file:
                 grammar, _ = parse(file, use_stdlib=False, use_cache=False)
+                assert grammar is not None
+                primer = PrimerVisitor(grammar.rules)
+                primer.prime()
 
     def test_contains_infinite_loops(self):
         grammar, primer = self.prime_infinite_loops_grammar()

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -227,7 +227,6 @@ class ConstraintTest(unittest.TestCase):
 
 
 class PrimerTest(unittest.TestCase):
-
     @staticmethod
     def prime_infinite_loops_grammar() -> tuple[Grammar, PrimerVisitor]:
         with open(RESOURCES_ROOT / "infinite_loops.fan", "r") as file:
@@ -250,9 +249,22 @@ class PrimerTest(unittest.TestCase):
         grammar, primer = self.prime_infinite_loops_grammar()
         rules = grammar.rules
         infinity = {"<inf_simple>", "<inf_complex>", "<inf_a>", "<inf_b>", "<inf_c>"}
-        non_infinity = {"<start>", "<escapable>", "<space>", "<name>", "<expr>", "<dig>",
-                        "<numeral>", "<factor>", "<term>"}
+        non_infinity = {
+            "<start>",
+            "<escapable>",
+            "<space>",
+            "<name>",
+            "<expr>",
+            "<dig>",
+            "<numeral>",
+            "<factor>",
+            "<term>",
+        }
         for name in infinity:
-            self.assertEqual(rules[NonTerminal(name)].distance_to_completion, float("inf"))
+            self.assertEqual(
+                rules[NonTerminal(name)].distance_to_completion, float("inf")
+            )
         for name in non_infinity:
-            self.assertLess(rules[NonTerminal(name)].distance_to_completion, float("inf"))
+            self.assertLess(
+                rules[NonTerminal(name)].distance_to_completion, float("inf")
+            )

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -9,7 +9,6 @@ from fandango.evolution.algorithm import DefaultAlgorithm
 from fandango.language.grammar.grammar import Grammar
 from fandango.language.grammar.node_visitors.primer import PrimerVisitor
 from fandango.language.grammar.nodes.node import Node
-from fandango.language.grammar.nodes.repetition import Repetition
 from fandango.language.parse.parse import parse
 from fandango.language.symbols import NonTerminal
 from fandango.language.tree import DerivationTree

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -247,23 +247,23 @@ class PrimerTest(unittest.TestCase):
     def test_who_is_infinite(self):
         grammar, primer = self.prime_infinite_loops_grammar()
         rules = grammar.rules
-        infinity = {"<inf_simple>", "<inf_complex>", "<inf_a>", "<inf_b>", "<inf_c>"}
-        non_infinity = {
-            "<start>",
-            "<escapable>",
-            "<space>",
-            "<name>",
-            "<expr>",
-            "<dig>",
-            "<numeral>",
-            "<factor>",
-            "<term>",
+        should_values = {
+            "<inf_simple>": float("inf"),
+            "<inf_complex>": float("inf"),
+            "<inf_a>": float("inf"),
+            "<inf_b>": float("inf"),
+            "<inf_c>": float("inf"),
+            "<start>": 13,
+            "<escapable>": 11,
+            "<space>": 1,
+            "<name>": 2,
+            "<expr>": 10,
+            "<dig>": 2,
+            "<numeral>": 4,
+            "<factor>": 6,
+            "<term>": 8,
         }
-        for name in infinity:
+        for name, dist in should_values.items():
             self.assertEqual(
-                rules[NonTerminal(name)].distance_to_completion, float("inf")
-            )
-        for name in non_infinity:
-            self.assertLess(
-                rules[NonTerminal(name)].distance_to_completion, float("inf")
+                rules[NonTerminal(name)].distance_to_completion, dist
             )

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -264,6 +264,4 @@ class PrimerTest(unittest.TestCase):
             "<term>": 8,
         }
         for name, dist in should_values.items():
-            self.assertEqual(
-                rules[NonTerminal(name)].distance_to_completion, dist
-            )
+            self.assertEqual(rules[NonTerminal(name)].distance_to_completion, dist)

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -4,8 +4,12 @@ import itertools
 import random
 import unittest
 
+from fandango.errors import FandangoValueError
 from fandango.evolution.algorithm import DefaultAlgorithm
+from fandango.language.grammar.grammar import Grammar
+from fandango.language.grammar.node_visitors.primer import PrimerVisitor
 from fandango.language.grammar.nodes.node import Node
+from fandango.language.grammar.nodes.repetition import Repetition
 from fandango.language.parse.parse import parse
 from fandango.language.symbols import NonTerminal
 from fandango.language.tree import DerivationTree
@@ -220,3 +224,35 @@ class ConstraintTest(unittest.TestCase):
             s = str(sol).split(".")
             self.assertEqual(s[0], "a" * 50, s[0])
             self.assertTrue(len(s[1]) >= 10)
+
+
+class PrimerTest(unittest.TestCase):
+
+    @staticmethod
+    def prime_infinite_loops_grammar() -> tuple[Grammar, PrimerVisitor]:
+        with open(RESOURCES_ROOT / "infinite_loops.fan", "r") as file:
+            grammar, _ = parse(file, use_stdlib=False, use_cache=False, check=False)
+        assert grammar is not None
+        primer = PrimerVisitor(grammar.rules)
+        primer.prime()
+        return grammar, primer
+
+    def test_error_on_parse(self):
+        with self.assertRaises(FandangoValueError):
+            with open(RESOURCES_ROOT / "infinite_loops.fan", "r") as file:
+                grammar, _ = parse(file, use_stdlib=False, use_cache=False)
+
+    def test_contains_infinite_loops(self):
+        grammar, primer = self.prime_infinite_loops_grammar()
+        self.assertTrue(primer.inf_loops, "Expected infinite loops")
+
+    def test_who_is_infinite(self):
+        grammar, primer = self.prime_infinite_loops_grammar()
+        rules = grammar.rules
+        infinity = {"<inf_simple>", "<inf_complex>", "<inf_a>", "<inf_b>", "<inf_c>"}
+        non_infinity = {"<start>", "<escapable>", "<space>", "<name>", "<expr>", "<dig>",
+                        "<numeral>", "<factor>", "<term>"}
+        for name in infinity:
+            self.assertEqual(rules[NonTerminal(name)].distance_to_completion, float("inf"))
+        for name in non_infinity:
+            self.assertLess(rules[NonTerminal(name)].distance_to_completion, float("inf"))


### PR DESCRIPTION
## What and why

Fixes https://github.com/fandango-fuzzer/fandango/issues/926

Instead of using a loop for priming, we now have a visitor that does the distance_to_completion computation.
(Easier to understand in my opinion). We break the stuck-in-priming issue by introducing a "changed" flag that, for each "priming" iteration, notes whether that iteration changed any distance_to_completion value. If nothing changed, priming is finished. Afterwards, we can filter out all nodes with infinite distance_to_completion. These then represent unbreakable loops, which let fandango not terminate before this commit. In case we detect such a loop, we terminate with an error and point to the non-terminals part of that unbreakable loop.

## How was it tested?

new unittest

## Checklist

- [x] Does one thing, and the diff is limited to what that needs
- [x] Tests cover any changed behaviour
- [x] Docs updated, if this changes something a user can see
- [x] `pre-commit` and `make tests` pass locally
- [x] `make lock` was run, if `pyproject.toml` dependencies changed
- [x] I understand what every changed line does and why it is there
- [x] I wrote this description myself, and said above if the change was
      substantially AI-assisted
