### PR TITLE
Fix: unreachable-symbol error when a packet symbol expands to another packet symbol

### DIFF
--- a/src/fandango/io/navigation/selection/protocol_model.py
+++ b/src/fandango/io/navigation/selection/protocol_model.py
@@ -18,6 +18,7 @@ class ProtocolModel:
     def __init__(self, grammar: Grammar, start_symbol: NonTerminal):
         self._grammar = grammar
         self.state_grammar_symbols = self._get_state_grammar_symbols(start_symbol)
+        self.protocol_msg_symbols = grammar.get_protocol_messages(start_symbol)
         self.permutation_groups = self._build_permutation_groups()
 
     def group_messages_by_nt(

--- a/src/fandango/io/navigation/selection/target_selector.py
+++ b/src/fandango/io/navigation/selection/target_selector.py
@@ -36,13 +36,23 @@ class TargetSelector:
     def _trim_to_state_symbols(self, uncovered_paths: list[KPath]) -> list[KPath]:
         """Trim each path back to its last state-grammar symbol; drop empties."""
         uncovered_paths = list(uncovered_paths)
+        protocol_msg_symbols = set(map(lambda x: x.symbol, self._model.protocol_msg_symbols))
         for list_idx, path in enumerate(list(uncovered_paths)):
-            remaining_path = path
-            for path_idx, symbol in enumerate(path[::-1]):
-                if symbol in self._model.state_grammar_symbols:
-                    break
-                last_idx = len(path) - path_idx - 1
-                remaining_path = remaining_path[:last_idx]
+            path_last_state_cutoff = len(path) + 1
+            in_state_area = True
+            # Make sure that parts of the k-path are in the state area of the grammar. Ignore otherwise
+            if len(path) > 0:
+                first_symbol = path[0]
+                if first_symbol not in self._model.state_grammar_symbols:
+                    in_state_area = False
+                    path_last_state_cutoff = 0
+            if in_state_area:
+                for path_idx, symbol in enumerate(path):
+                    # Truncate k-path at first occurrence of a message symbol
+                    if symbol in protocol_msg_symbols:
+                        path_last_state_cutoff = path_idx + 1
+                        break
+            remaining_path = path[:path_last_state_cutoff]
             uncovered_paths[list_idx] = remaining_path
         return list(filter(lambda x: len(x) > 0, uncovered_paths))
 

--- a/src/fandango/io/navigation/selection/target_selector.py
+++ b/src/fandango/io/navigation/selection/target_selector.py
@@ -36,7 +36,9 @@ class TargetSelector:
     def _trim_to_state_symbols(self, uncovered_paths: list[KPath]) -> list[KPath]:
         """Trim each path back to its last state-grammar symbol; drop empties."""
         uncovered_paths = list(uncovered_paths)
-        protocol_msg_symbols = set(map(lambda x: x.symbol, self._model.protocol_msg_symbols))
+        protocol_msg_symbols = set(
+            map(lambda x: x.symbol, self._model.protocol_msg_symbols)
+        )
         for list_idx, path in enumerate(list(uncovered_paths)):
             path_last_state_cutoff = len(path) + 1
             in_state_area = True

--- a/src/fandango/language/grammar/nodes/non_terminal.py
+++ b/src/fandango/language/grammar/nodes/non_terminal.py
@@ -107,8 +107,12 @@ class NonTerminalNode(Node):
             return self.symbol.format_as_spec()
 
     def __eq__(self, other: object) -> bool:
-        return (isinstance(other, NonTerminalNode) and self.symbol == other.symbol
-                and self.sender == other.sender and self.recipient == other.recipient)
+        return (
+            isinstance(other, NonTerminalNode)
+            and self.symbol == other.symbol
+            and self.sender == other.sender
+            and self.recipient == other.recipient
+        )
 
     def __hash__(self) -> int:
         return hash((self.symbol, self.sender, self.recipient))

--- a/src/fandango/language/grammar/nodes/non_terminal.py
+++ b/src/fandango/language/grammar/nodes/non_terminal.py
@@ -107,10 +107,11 @@ class NonTerminalNode(Node):
             return self.symbol.format_as_spec()
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, NonTerminalNode) and self.symbol == other.symbol
+        return (isinstance(other, NonTerminalNode) and self.symbol == other.symbol
+                and self.sender == other.sender and self.recipient == other.recipient)
 
     def __hash__(self) -> int:
-        return hash(self.symbol)
+        return hash((self.symbol, self.sender, self.recipient))
 
     def msg_parties(
         self,

--- a/tests/resources/cross_reference_protocol_msg.fan
+++ b/tests/resources/cross_reference_protocol_msg.fan
@@ -1,0 +1,15 @@
+<start> ::= <Party:msg_a><Party:msg_b>
+<msg_a> ::= 'example'
+<msg_b> ::= <msg_a>
+
+class Party(FandangoParty):
+    def __init__(self):
+        super().__init__(connection_mode=ConnectionMode.OPEN)
+
+    def send(
+        self,
+        message: DerivationTree,
+        recipient: str
+    ):
+        pass
+        

--- a/tests/test_grammar_graph.py
+++ b/tests/test_grammar_graph.py
@@ -271,7 +271,6 @@ class Server(FandangoParty):
 
 
 class TestTargetSelector(unittest.TestCase):
-
     def test_cross_reference_msgs(self):
         with open(RESOURCES_ROOT / "cross_reference_protocol_msg.fan") as f:
             grammar, constraints = parse(
@@ -286,7 +285,11 @@ class TestTargetSelector(unittest.TestCase):
         b_follows_a = tuple([nt_msg_b, nt_msg_a])
         pm = ProtocolModel(grammar, start_symbol)
         ts = TargetSelector(grammar, start_symbol, pm)
-        all_paths = list(grammar.generate_all_k_paths(k=5, non_terminal=start_symbol, input_parties={"Party"}))
+        all_paths = list(
+            grammar.generate_all_k_paths(
+                k=5, non_terminal=start_symbol, input_parties={"Party"}
+            )
+        )
         for _ in range(10):
             target = ts.select(all_paths, [])
             self.assertFalse(PacketGuide._tuple_contains(a_follows_b, target))

--- a/tests/test_grammar_graph.py
+++ b/tests/test_grammar_graph.py
@@ -7,6 +7,9 @@ from fandango.io.navigation.graph.packetnavigator import PacketNavigator
 from fandango.io.navigation.graph.reachability_checker import ReachabilityChecker
 from fandango.io.navigation.graph.stategrammarconverter import StateGrammarConverter
 from fandango.io.navigation.PacketNonTerminal import PacketNonTerminal
+from fandango.io.navigation.selection.packet_guide import PacketGuide
+from fandango.io.navigation.selection.protocol_model import ProtocolModel
+from fandango.io.navigation.selection.target_selector import TargetSelector
 from fandango.language import DerivationTree, NonTerminal
 from fandango.language.grammar import ParsingMode
 from fandango.language.grammar.grammar import Grammar, KPath
@@ -265,3 +268,26 @@ class Server(FandangoParty):
             tree=hist_tree, destination_k_path=dest_k_path
         )
         self.assertIsNotNone(path)
+
+
+class TestTargetSelector(unittest.TestCase):
+
+    def test_cross_reference_msgs(self):
+        with open(RESOURCES_ROOT / "cross_reference_protocol_msg.fan") as f:
+            grammar, constraints = parse(
+                [f],
+                use_stdlib=False,
+            )
+        assert grammar is not None
+        start_symbol = NonTerminal("<start>")
+        nt_msg_a = NonTerminal("<msg_a>")
+        nt_msg_b = NonTerminal("<msg_b>")
+        a_follows_b = tuple([nt_msg_a, nt_msg_b])
+        b_follows_a = tuple([nt_msg_b, nt_msg_a])
+        pm = ProtocolModel(grammar, start_symbol)
+        ts = TargetSelector(grammar, start_symbol, pm)
+        all_paths = list(grammar.generate_all_k_paths(k=5, non_terminal=start_symbol, input_parties={"Party"}))
+        for _ in range(10):
+            target = ts.select(all_paths, [])
+            self.assertFalse(PacketGuide._tuple_contains(a_follows_b, target))
+            self.assertFalse(PacketGuide._tuple_contains(b_follows_a, target))


### PR DESCRIPTION
## What and why

Fixed the bug described in issue #860:

Consider the following grammar:

```
<start> ::= <Party:msg_a><Party:msg_b>
<msg_a> ::= 'example'
<msg_b> ::= <msg_a>
```

This grammar can lead to a navigation error with the error message:
```
raise FandangoError(fandango.errors.FandangoError: Symbol (NonTerminal(<start>), NonTerminal(<_packet_msg_b>), NonTerminal(<_packet_msg_a>)) is not reachable in grammar.
```

This happens because `<msg_b>` expands to `<msg_a>`, while both `<msg_a>` and `<msg_b>` appear in contexts annotated with a sending party. As a result, the navigation logic may treat both as packet-level symbols. When computing a route for the corresponding k-path, the system may attempt to reach a sequence involving both packetized symbols even though such a path is not actually reachable in the grammar.


## How was it tested?

New unittest

## Checklist

- [x] Does one thing, and the diff is limited to what that needs
- [x] Tests cover any changed behaviour
- [x] Docs updated, if this changes something a user can see
- [x] `pre-commit` and `make tests` pass locally
- [x] `make lock` was run, if `pyproject.toml` dependencies changed
- [x] I understand what every changed line does and why it is there
- [x] I wrote this description myself, and said above if the change was
      substantially AI-assisted
