### PR TITLE
Only have one dependabot PR for minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,9 @@ updates:
     schedule:
       interval: weekly
     groups:
-      minor-updates:
+      minor-and-patch-updates:
         update-types:
           - "minor"
-      patch-updates:
-        update-types:
           - "patch"
     patterns:
       - "*"


### PR DESCRIPTION
## What and why

We currently get separate PRs for minor and patch updates from dependabot. I don't think I've seen Fandango break because of either, so I'd like to merge these groups such that we only get one PR for either category.

This still leaves separate PRs for major updates and those that do not conform to semantic versions.

## How was it tested?

I looked at it really hard :)

## Checklist

- [x] Does one thing, and the diff is limited to what that needs
- [x] Tests cover any changed behaviour
- [x] Docs updated, if this changes something a user can see
- [x] `pre-commit` and `make tests` pass locally
- [x] `make lock` was run, if `pyproject.toml` dependencies changed
- [x] I understand what every changed line does and why it is there
- [x] I wrote this description myself, and said above if the change was
      substantially AI-assisted
